### PR TITLE
Add support for OpenAPI DataTypes

### DIFF
--- a/Sources/Swiftgger/APIModel/APIParameter.swift
+++ b/Sources/Swiftgger/APIModel/APIParameter.swift
@@ -15,6 +15,7 @@ public class APIParameter {
     var required: Bool = false
     var deprecated: Bool = false
     var allowEmptyValue: Bool = false
+    var dataType: APIDataType = APIDataType.string
 
     public init(
         name: String,
@@ -22,7 +23,8 @@ public class APIParameter {
         description: String? = nil,
         required: Bool = false,
         deprecated: Bool = false,
-        allowEmptyValue: Bool = false
+        allowEmptyValue: Bool = false,
+        dataType: APIDataType = APIDataType.string
     ) {
         self.name = name
         self.parameterLocation = parameterLocation
@@ -30,5 +32,6 @@ public class APIParameter {
         self.required = required
         self.deprecated = deprecated
         self.allowEmptyValue = allowEmptyValue
+        self.dataType = dataType
     }
 }

--- a/Sources/Swiftgger/Builder/OpenAPIParametersBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIParametersBuilder.swift
@@ -31,7 +31,8 @@ class OpenAPIParametersBuilder {
                 description: apiParameter.description,
                 required: apiParameter.required,
                 deprecated: apiParameter.deprecated,
-                allowEmptyValue: apiParameter.allowEmptyValue
+                allowEmptyValue: apiParameter.allowEmptyValue,
+                schema: OpenAPISchema(type: "string")
             )
 
             openApiParameters.append(openAPIParameter)

--- a/Sources/Swiftgger/Builder/OpenAPIParametersBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIParametersBuilder.swift
@@ -32,7 +32,7 @@ class OpenAPIParametersBuilder {
                 required: apiParameter.required,
                 deprecated: apiParameter.deprecated,
                 allowEmptyValue: apiParameter.allowEmptyValue,
-                schema: OpenAPISchema(type: "string")
+                schema: OpenAPISchema(type: apiParameter.dataType.type, format: apiParameter.dataType.format)
             )
 
             openApiParameters.append(openAPIParameter)

--- a/Sources/Swiftgger/Common/APIDataType.swift
+++ b/Sources/Swiftgger/Common/APIDataType.swift
@@ -1,0 +1,26 @@
+//
+//  APIDataType.swift
+//  Swiftgger
+//
+//  Created by Eneko Alonso on 2/2/19.
+//
+
+import Foundation
+
+/// OpenAPI Data Types as specified in https://swagger.io/specification/#dataTypes
+public struct APIDataType {
+    let type: String
+    let format: String?
+
+    public static let int32 = APIDataType(type: "integer", format: "int32")
+    public static let int64 = APIDataType(type: "integer", format: "int64")
+    public static let float = APIDataType(type: "number", format: "float")
+    public static let double = APIDataType(type: "number", format: "double")
+    public static let string = APIDataType(type: "string", format: nil)
+    public static let byte = APIDataType(type: "string", format: "byte")
+    public static let binary = APIDataType(type: "string", format: "binary")
+    public static let boolean = APIDataType(type: "boolean", format: nil)
+    public static let date = APIDataType(type: "string", format: "date")
+    public static let dateTime = APIDataType(type: "string", format: "date-time")
+    public static let password = APIDataType(type: "string", format: "password")
+}

--- a/Sources/Swiftgger/OpenAPIModel/OpenAPIObjectProperty.swift
+++ b/Sources/Swiftgger/OpenAPIModel/OpenAPIObjectProperty.swift
@@ -11,10 +11,12 @@ import Foundation
 public class OpenAPIObjectProperty: Encodable {
 
     public private(set) var type: String
+    public private(set) var format: String?
     public private(set) var example: String?
 
-    init(type: String, example: String?) {
+    init(type: String, format: String?, example: String?) {
         self.type = type
+        self.format = format
         self.example = example
     }
 }

--- a/Sources/Swiftgger/OpenAPIModel/OpenAPIParameter.swift
+++ b/Sources/Swiftgger/OpenAPIModel/OpenAPIParameter.swift
@@ -20,6 +20,7 @@ public class OpenAPIParameter: Encodable {
     public private(set) var required: Bool = false
     public private(set) var deprecated: Bool = false
     public private(set) var allowEmptyValue: Bool = false
+    public private(set) var schema: OpenAPISchema?
 
     init(ref: String) {
         self.ref = ref
@@ -31,7 +32,8 @@ public class OpenAPIParameter: Encodable {
         description: String? = nil,
         required: Bool = false,
         deprecated: Bool = false,
-        allowEmptyValue: Bool = false
+        allowEmptyValue: Bool = false,
+        schema: OpenAPISchema
     ) {
         self.name = name
         self.parameterLocation = parameterLocation
@@ -39,6 +41,7 @@ public class OpenAPIParameter: Encodable {
         self.required = required
         self.deprecated = deprecated
         self.allowEmptyValue = allowEmptyValue
+        self.schema = schema
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -49,5 +52,6 @@ public class OpenAPIParameter: Encodable {
         case required
         case deprecated
         case allowEmptyValue
+        case schema
     }
 }

--- a/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
+++ b/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
@@ -12,6 +12,7 @@ public class OpenAPISchema: Encodable {
 
     public private(set) var ref: String?
     public private(set) var type: String?
+    public private(set) var format: String?
     public private(set) var items: OpenAPISchema?
     public private(set) var required: [String]?
     public private(set) var properties: [String: OpenAPIObjectProperty]?
@@ -20,8 +21,11 @@ public class OpenAPISchema: Encodable {
         self.ref = ref
     }
 
-    init(type: String? = nil, items: OpenAPISchema? = nil, required: [String]? = nil, properties: [(name: String, type: OpenAPIObjectProperty)]? = nil) {
+    init(type: String? = nil, format: String? = nil,
+         items: OpenAPISchema? = nil, required: [String]? = nil,
+         properties: [(name: String, type: OpenAPIObjectProperty)]? = nil) {
         self.type = type
+        self.format = format
         self.items = items
         self.required = required
 
@@ -36,6 +40,7 @@ public class OpenAPISchema: Encodable {
     private enum CodingKeys: String, CodingKey {
         case ref = "$ref"
         case type
+        case format
         case items
         case required
         case properties

--- a/Tests/SwiftggerTests/OpenAPIParametersBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPIParametersBuilderTests.swift
@@ -183,7 +183,7 @@ class OpenAPIParametersBuilderTests: XCTestCase {
             .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
                 APIAction(method: .get, route: "/animals", summary: "Action summary",
                           description: "Action description", parameters: [
-                            APIParameter(name: "animalId", parameterLocation: .path)
+                            APIParameter(name: "animalId", parameterLocation: .query)
                     ])
                 ]))
 
@@ -191,7 +191,7 @@ class OpenAPIParametersBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertEqual(.path, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.parameterLocation)
+        XCTAssertEqual(APILocation.query, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.parameterLocation)
     }
 
     func testParameterEmptyValueShouldBeAddedToOpenAPIDocument() {

--- a/Tests/SwiftggerTests/OpenAPIParametersBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPIParametersBuilderTests.swift
@@ -1,0 +1,296 @@
+//
+//  OpenAPIParametersBuilderTests.swift
+//  SwiftggerTests
+//
+//  Created by Eneko Alonso on 2/2/19.
+//
+
+import XCTest
+@testable import Swiftgger
+
+/**
+    Tests for paths components in OpenAPI standard (/paths).
+
+    ```
+    "paths": {
+        "/animals/{animalId}": {
+            "get": {
+                "summary": "Returns a pet by Id",
+                "description": "Returns a pet by Id from the system that the user has access to",
+                "parameters": [
+                  {
+                    "schema" : {
+                      "type" : "string"
+                    },
+                    "in" : "path",
+                    "allowEmptyValue" : false,
+                    "deprecated" : false,
+                    "description" : "Pet Id",
+                    "required" : true,
+                    "name" : "animalId"
+                  }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A list of pets.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/pet"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            "post": {
+                "summary": "Update an existing pet",
+                "description": "Update an existing pet in the system",
+                "parameters": [
+                  {
+                    "schema" : {
+                      "type" : "string"
+                    },
+                    "in" : "path",
+                    "allowEmptyValue" : false,
+                    "deprecated" : false,
+                    "description" : "Pet Id",
+                    "required" : true,
+                    "name" : "animalId"
+                  }
+                ],
+                "requestBody": {
+                    "description": "A pet.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/pet"
+                            }
+                        }
+                    }
+                }
+                "responses": {
+                    "200": {
+                        "description": "A pet."
+                    }
+                }
+            }
+        }
+    }
+    ```
+ */
+class OpenAPIParametersBuilderTests: XCTestCase {
+
+    func testParameterShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId")
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.paths["/animals"]?.get?.parameters?.first, "Parameter should be added to the tree.")
+    }
+
+    func testParameterNameShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId")
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("animalId", openAPIDocument.paths["/animals"]?.get?.parameters?.first?.name)
+    }
+
+    func testParameterRequiredShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", required: true)
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual(true, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.required)
+    }
+
+    func testParameterDescriptionShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", description: "Animal ID")
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("Animal ID", openAPIDocument.paths["/animals"]?.get?.parameters?.first?.description)
+    }
+
+    func testParameterLocationShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", parameterLocation: .path)
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual(.path, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.parameterLocation)
+    }
+
+    func testParameterEmptyValueShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", allowEmptyValue: true)
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual(true, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.allowEmptyValue)
+    }
+
+    func testParameterDeprecationShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", deprecated: true)
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual(true, openAPIDocument.paths["/animals"]?.get?.parameters?.first?.deprecated)
+    }
+
+    func testParameterSchemaTypeShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId")
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("string", openAPIDocument.paths["/animals"]?.get?.parameters?.first?.schema?.type)
+    }
+
+    func testParameterSchemaFormatShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+            )
+            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+                APIAction(method: .get, route: "/animals", summary: "Action summary",
+                          description: "Action description", parameters: [
+                            APIParameter(name: "animalId", dataType: .int64)
+                    ])
+                ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("int64", openAPIDocument.paths["/animals"]?.get?.parameters?.first?.schema?.format)
+    }
+
+    static var allTests = [
+        ("testParameterShouldBeAddedToOpenAPIDocument", testParameterShouldBeAddedToOpenAPIDocument),
+        ("testParameterNameShouldBeAddedToOpenAPIDocument", testParameterNameShouldBeAddedToOpenAPIDocument),
+        ("testParameterRequiredShouldBeAddedToOpenAPIDocument", testParameterRequiredShouldBeAddedToOpenAPIDocument),
+        ("testParameterDescriptionShouldBeAddedToOpenAPIDocument", testParameterDescriptionShouldBeAddedToOpenAPIDocument),
+        ("testParameterLocationShouldBeAddedToOpenAPIDocument", testParameterLocationShouldBeAddedToOpenAPIDocument),
+        ("testParameterEmptyValueShouldBeAddedToOpenAPIDocument", testParameterEmptyValueShouldBeAddedToOpenAPIDocument),
+        ("testParameterDeprecationShouldBeAddedToOpenAPIDocument", testParameterDeprecationShouldBeAddedToOpenAPIDocument),
+        ("testParameterSchemaTypeShouldBeAddedToOpenAPIDocument", testParameterSchemaTypeShouldBeAddedToOpenAPIDocument),
+        ("testParameterSchemaFormatShouldBeAddedToOpenAPIDocument", testParameterSchemaFormatShouldBeAddedToOpenAPIDocument)
+    ]
+}

--- a/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
@@ -38,7 +38,8 @@ struct Spaceship {
                  "type": "object",
                  "properties": {
                      "age": {
-                         "type": "int",
+                         "type": "integer",
+                         "format": "int64"
                      },
                      "name": {
                         "type": "string"
@@ -74,7 +75,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas!["Vehicle"], "Schema name not exists")
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"], "Schema name not exists")
     }
 
     func testSchemaTypeShouldBeTranslatedToOpenAPIDocument() {
@@ -93,7 +94,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertEqual("object", openAPIDocument.components?.schemas!["Vehicle"]?.type)
+        XCTAssertEqual("object", openAPIDocument.components?.schemas?["Vehicle"]?.type)
     }
 
     func testSchemaStringPropertyShouldBeTranslatedToOpenAPIDocument() {
@@ -112,9 +113,9 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas!["Vehicle"]?.properties!["name"], "String property not exists in schema")
-        XCTAssertEqual("string", openAPIDocument.components?.schemas!["Vehicle"]?.properties!["name"]?.type)
-        XCTAssertEqual("Ford", openAPIDocument.components?.schemas!["Vehicle"]?.properties!["name"]?.example)
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"]?.properties?["name"], "String property not exists in schema")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["name"]?.type)
+        XCTAssertEqual("Ford", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["name"]?.example)
     }
 
     func testSchemaIntegerPropertyShouldBeTranslatedToOpenAPIDocument() {
@@ -133,9 +134,10 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas!["Vehicle"]?.properties!["age"], "Integer property not exists in schema")
-        XCTAssertEqual("int", openAPIDocument.components?.schemas!["Vehicle"]?.properties!["age"]?.type)
-        XCTAssertEqual("21", openAPIDocument.components?.schemas!["Vehicle"]?.properties!["age"]?.example)
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"], "Integer property not exists in schema")
+        XCTAssertEqual("integer", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.type)
+        XCTAssertEqual("int64", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.format)
+        XCTAssertEqual("21", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.example)
     }
 
     func testSchemaRequiredFieldsShouldBeTranslatedToOpenAPIDocument() {
@@ -154,7 +156,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssert(openAPIDocument.components?.schemas!["Vehicle"]?.required?.contains("name") == true, "Required property not exists in schema")
+        XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("name") == true, "Required property not exists in schema")
     }
 
     func testSchemaNotRequiredFieldsShouldNotBeTranslatedToOpenAPIDocument() {
@@ -173,7 +175,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssert(openAPIDocument.components?.schemas!["Vehicle"]?.required?.contains("age") == false, "Not required property exists in schema")
+        XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("age") == false, "Not required property exists in schema")
     }
 
     func testSchemaStructTypeShouldBeTranslatedToOpenAPIDocument() {
@@ -192,11 +194,12 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas!["Spaceship"], "Schema name not exists")
-        XCTAssertEqual("string", openAPIDocument.components?.schemas!["Spaceship"]?.properties!["name"]?.type)
-        XCTAssertEqual("Star Trek", openAPIDocument.components?.schemas!["Spaceship"]?.properties!["name"]?.example)
-        XCTAssertEqual("double", openAPIDocument.components?.schemas!["Spaceship"]?.properties!["speed"]?.type)
-        XCTAssertEqual("923211.0", openAPIDocument.components?.schemas!["Spaceship"]?.properties!["speed"]?.example)
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Spaceship"], "Schema name not exists")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["name"]?.type)
+        XCTAssertEqual("Star Trek", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["name"]?.example)
+        XCTAssertEqual("number", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["speed"]?.type)
+        XCTAssertEqual("double", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["speed"]?.format)
+        XCTAssertEqual("923211.0", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["speed"]?.example)
     }
 
     static var allTests = [


### PR DESCRIPTION
Hi Marcin!

First of all, thank you very much for this open source library. It covers great part of the OpenAPI 3.0.0 specification, which is pretty awesome.

While using Swiftgger, I noticed this issue where the output specification is not valid: 
[#2 Parameter error: "😱 Could not render this component, see the console."](https://github.com/mczachurski/Swiftgger/issues/2)

I investigated a little bit and decided to put together this API to add initial support for OpenAPI Data Types (as seen at https://swagger.io/specification/#dataTypes).

For request parameters, the data type can be directly specified when defining an `APIParameter`:

```swift
APIParameter(name: "animalId", dataType: .int64)
```

For schema objects, the data type is inferred from the Swift values of each property. This would allow us to keep using `Codable` data models to define our `APIObjects`, without having to manually specify the data type for each property.

This pull request adds support for the following Swift types:

| Swift Type | OpenAPI Type | OpenAPI Format |
| ---------- | --------------- | ---------------- |
| `Int32`      | `"integer"`       | `"int32"`             | 
| `Int64`      | `"integer"`       | `"int64"`             | 
| `Float`       | `"number"`     | `"float"`               | 
| `Double`   | `"number"`     | `"double"`           | 
| `Bool`       | `"boolean"`       | `nil`                    | 
| `Date`       | `"string"`       | `"date-time"`       | 
| `String`     | `"string"`       | `nil`                       | 

Further types can be added later on, including support for collections (arrays) and nested objects.

Regards,
Eneko

PS: I'd be happy to become a maintainer for this repository.