### PR TITLE
Add OAuth2 authorization support

### DIFF
--- a/Sources/Swiftgger/APIModel/APIAuthorizationFlow.swift
+++ b/Sources/Swiftgger/APIModel/APIAuthorizationFlow.swift
@@ -1,0 +1,24 @@
+//
+//  APIAuthorizationFlow.swift
+//  Swiftgger
+//
+//  Created by Marcin Czachurski on 23.01.2021.
+//
+
+import Foundation
+
+/// Configuration details for a supported OAuth Flow.
+public class APIAuthorizationFlow {
+
+    var authorizationUrl: String
+    var tokenUrl: String
+    var refreshUrl: String?
+    var scopes: [String: String]
+
+    public init(authorizationUrl: String, tokenUrl: String, scopes: [String: String], refreshUrl: String? = nil) {
+        self.authorizationUrl = authorizationUrl
+        self.tokenUrl = tokenUrl
+        self.scopes = scopes
+        self.refreshUrl = refreshUrl
+    }
+}

--- a/Sources/Swiftgger/APIModel/APIAuthorizationOAuth2Type.swift
+++ b/Sources/Swiftgger/APIModel/APIAuthorizationOAuth2Type.swift
@@ -1,0 +1,23 @@
+//
+//  APIAuthorizationOAuth2Type.swift
+//  Swiftgger
+//
+//  Created by Marcin Czachurski on 23.01.2021.
+//
+
+import Foundation
+
+/**
+    Kind of OAuth2 authorizations.
+
+    - implicit: Configuration for the OAuth Implicit flow.
+    - password: Configuration for the OAuth Resource Owner Password flow.
+    - clientCredentials: Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0.
+    - authorizationCode: Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0.
+ */
+public enum APIAuthorizationOAuth2Type {
+    case implicit(APIAuthorizationFlow)
+    case password(APIAuthorizationFlow)
+    case clientCredentials(APIAuthorizationFlow)
+    case authorizationCode(APIAuthorizationFlow)
+}

--- a/Sources/Swiftgger/APIModel/APIAuthorizationType.swift
+++ b/Sources/Swiftgger/APIModel/APIAuthorizationType.swift
@@ -19,4 +19,5 @@ public enum APIAuthorizationType {
     case basic(description: String)
     case jwt(description: String)
     case apiKey(description: String)
+    case oauth2(description: String, flows: [APIAuthorizationOAuth2Type])
 }

--- a/Sources/Swiftgger/Builder/OpenAPIOperationBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIOperationBuilder.swift
@@ -33,8 +33,8 @@ class OpenAPIOperationBuilder {
         let openAPIResponsesBuilder = OpenAPIResponsesBuilder(responses: action.responses, objects: objects)
         let openAPIResponses = openAPIResponsesBuilder.built()
 
-        let openAPISecuritySchemasBuilder = OpenAPISecuritySchemasBuilder(authorization: action.authorization,
-                                                                        authorizations: authorizations)
+        let openAPISecuritySchemasBuilder = OpenAPISecurityActionsBuilder(authorization: action.authorization,
+                                                                         authorizations: authorizations)
         let securitySchemas = openAPISecuritySchemasBuilder.built()
 
         let openAPIOperation = OpenAPIOperation(

--- a/Sources/Swiftgger/Builder/OpenAPISecurityActionsBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISecurityActionsBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  OpenAPISecuritySchemasBuilder.swift
+//  OpenAPISecurityActionsBuilder.swift
 //  Swiftgger
 //
 //  Created by Marcin Czachurski on 25.03.2018.
@@ -7,8 +7,8 @@
 
 import Foundation
 
-/// Builder for security information stored in `components/securitySchemas` part of OpenAPI.
-class OpenAPISecuritySchemasBuilder {
+/// Builder for security information for each HTTP action.
+class OpenAPISecurityActionsBuilder {
     
     let authorizations: [APIAuthorizationType]?
     let authorization: Bool
@@ -38,6 +38,10 @@ class OpenAPISecuritySchemasBuilder {
                 case .apiKey:
                     var securityDict: [String: [String]] = [:]
                     securityDict["api_key"] = []
+                    securitySchemas!.append(securityDict)
+                case .oauth2(description: _, flows: _):
+                    var securityDict: [String: [String]] = [:]
+                    securityDict["oauth2"] = []
                     securitySchemas!.append(securityDict)
                 case .anonymous:
                     break

--- a/Sources/Swiftgger/Builder/OpenAPISecurityBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISecurityBuilder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Builder for security information for each HTTP action.
+/// Builder for security information stored in `components/securitySchemas` part of OpenAPI.
 class OpenAPISecurityBuilder {
     let authorizations: [APIAuthorizationType]?
     
@@ -46,11 +46,52 @@ class OpenAPISecurityBuilder {
                                                        name: "X-API-KEY",
                                                        parameterLocation: .header)
                 openAPISecuritySchema["api_key"] = apiKeyAuth
+            case .oauth2(description: let description, flows: let flows):
+                
+                var implicit: OpenAPIOAuthFlow?
+                var password: OpenAPIOAuthFlow?
+                var clientCredentials: OpenAPIOAuthFlow?
+                var authorizationCode: OpenAPIOAuthFlow?
+
+                for flow in flows {
+                    switch flow {
+                    case .implicit(let implicitFlow):
+                        implicit = self.mapToOpenAPIOAuthFlow(from: implicitFlow)
+                        break
+                    case .password(let passwordFlow):
+                        password = self.mapToOpenAPIOAuthFlow(from: passwordFlow)
+                        break
+                    case .clientCredentials(let clientCredentialsFlow):
+                        clientCredentials = self.mapToOpenAPIOAuthFlow(from: clientCredentialsFlow)
+                        break
+                    case .authorizationCode(let authorizationCodeFlow):
+                        authorizationCode = self.mapToOpenAPIOAuthFlow(from: authorizationCodeFlow)
+                        break
+                    }
+                }
+                
+                let openAPIOAuthFlows = OpenAPIOAuthFlows(implicit: implicit,
+                                                          password: password,
+                                                          clientCredentials: clientCredentials,
+                                                          authorizationCode: authorizationCode)
+                
+                let oauth2Auth = OpenAPISecurityScheme(type: "oauth2",
+                                                       description: description,
+                                                       flows: openAPIOAuthFlows)
+
+                openAPISecuritySchema["oauth2"] = oauth2Auth
             case .anonymous:
                 break
             }
         }
         
         return openAPISecuritySchema
+    }
+    
+    private func mapToOpenAPIOAuthFlow(from flow: APIAuthorizationFlow) -> OpenAPIOAuthFlow {
+        return OpenAPIOAuthFlow(authorizationUrl: flow.authorizationUrl,
+                                tokenUrl: flow.tokenUrl,
+                                refreshUrl: flow.refreshUrl,
+                                scopes: flow.scopes)
     }
 }

--- a/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
+++ b/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
@@ -21,9 +21,12 @@ public class OpenAPISchema: Codable {
         self.ref = ref
     }
 
-    init(type: String? = nil, format: String? = nil,
-         items: OpenAPISchema? = nil, required: [String]? = nil,
-         properties: [(name: String, type: OpenAPIObjectProperty)]? = nil) {
+    init(type: String? = nil,
+         format: String? = nil,
+         items: OpenAPISchema? = nil,
+         required: [String]? = nil,
+         properties: [(name: String, type: OpenAPIObjectProperty)]? = nil
+    ) {
         self.type = type
         self.format = format
         self.items = items


### PR DESCRIPTION
There is possible now to add OAuth2 authorisation:

```swift
let openAPIBuilder = OpenAPIBuilder(
    title: "Title",
    version: "1.0.0",
    description: "Description",
    authorizations: [
        .oauth2(description: "OAuth authorization", flows: [
            .implicit(APIAuthorizationFlow(authorizationUrl: "https://oauth2.com", tokenUrl: "https://oauth2.com/token", scopes: [:]))
        ])
    ]
)
```