### PR TITLE
Add OpenId authorization support

### DIFF
--- a/Sources/Swiftgger/APIModel/APIAuthorizationType.swift
+++ b/Sources/Swiftgger/APIModel/APIAuthorizationType.swift
@@ -20,4 +20,5 @@ public enum APIAuthorizationType {
     case jwt(description: String)
     case apiKey(description: String)
     case oauth2(description: String, flows: [APIAuthorizationOAuth2Type])
+    case openId(description: String, openIdConnectUrl: String)
 }

--- a/Sources/Swiftgger/Builder/OpenAPISecurityActionsBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISecurityActionsBuilder.swift
@@ -26,25 +26,28 @@ class OpenAPISecurityActionsBuilder {
             securitySchemas = []
             
             for authorization in self.authorizations! {
+                
+                var authorizationName: String?
+                
                 switch authorization {
                 case .basic(description: _):
-                    var securityDict: [String: [String]] = [:]
-                    securityDict["auth_basic"] = []
-                    securitySchemas!.append(securityDict)
+                    authorizationName = "auth_basic"
                 case .jwt(description: _):
-                    var securityDict: [String: [String]] = [:]
-                    securityDict["auth_jwt"] = []
-                    securitySchemas!.append(securityDict)
+                    authorizationName = "auth_jwt"
                 case .apiKey:
-                    var securityDict: [String: [String]] = [:]
-                    securityDict["api_key"] = []
-                    securitySchemas!.append(securityDict)
+                    authorizationName = "api_key"
                 case .oauth2(description: _, flows: _):
-                    var securityDict: [String: [String]] = [:]
-                    securityDict["oauth2"] = []
-                    securitySchemas!.append(securityDict)
+                    authorizationName = "oauth2"
+                case .openId(description: _, openIdConnectUrl: _):
+                    authorizationName = "openId"
                 case .anonymous:
                     break
+                }
+                
+                if let authorizationName = authorizationName {
+                    var securityDict: [String: [String]] = [:]
+                    securityDict[authorizationName] = []
+                    securitySchemas!.append(securityDict)
                 }
             }
         }

--- a/Sources/Swiftgger/Builder/OpenAPISecurityBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISecurityBuilder.swift
@@ -80,6 +80,12 @@ class OpenAPISecurityBuilder {
                                                        flows: openAPIOAuthFlows)
 
                 openAPISecuritySchema["oauth2"] = oauth2Auth
+            case .openId(description: let description, openIdConnectUrl: let openIdConnectUrl):
+                let openIdAuth = OpenAPISecurityScheme(type: "openIdConnect",
+                                                       description: description,
+                                                       openIdConnectUrl: openIdConnectUrl)
+                openAPISecuritySchema["openId"] = openIdAuth
+                break
             case .anonymous:
                 break
             }

--- a/Tests/SwiftggerTests/OpenAPISecurityBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPISecurityBuilderTests.swift
@@ -113,6 +113,27 @@ class OpenAPISecurityBuilderTests: XCTestCase {
         XCTAssertEqual("https://oauth2.com", securitySchema?.flows?.implicit?.authorizationUrl)
         XCTAssertEqual("https://oauth2.com/token", securitySchema?.flows?.implicit?.tokenUrl)
     }
+    
+    func testOpenIdAuthorizationsShouldBeTranslatedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description",
+            authorizations: [
+                .openId(description: "OpenIdConnect authorization", openIdConnectUrl: "https//opeind.com")
+            ]
+        )
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        let securitySchema = openAPIDocument.components?.securitySchemes!["openId"]
+        XCTAssertEqual("openIdConnect", securitySchema?.type)
+        XCTAssertEqual("https//opeind.com", securitySchema?.openIdConnectUrl)
+    }
 
     func testBearerAuthorizationForActionsShouldBeTranslatedToOpenAPIDocument() {
 
@@ -201,5 +222,28 @@ class OpenAPISecurityBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.paths["/animals"]?.get?.security![0]["oauth2"], "OAuth2 authorization should be enabled")
+    }
+    
+    func testOpenIdAuthorizationForActionsShouldBeTranslatedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description",
+            authorizations: [
+                .openId(description: "OpenIdConnect authorization", openIdConnectUrl: "https//opeind.com")
+            ]
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/animals", summary: "Action summary",
+                      description: "Action description", authorization: true)
+            ]))
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.paths["/animals"]?.get?.security![0]["openId"], "OpenId authorization should be enabled")
     }
 }


### PR DESCRIPTION
Add support of OpenId authorisation:

```swift
let openAPIBuilder = OpenAPIBuilder(
    title: "Title",
    version: "1.0.0",
    description: "Description",
    authorizations: [
        .openId(description: "OpenIdConnect authorization", openIdConnectUrl: "https//opeind.com")
    ]
)
```