### PR TITLE
Support of simple value types in request/response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ let package = Package(
 )
 ``` 
 
+> Swiftgger requires at least version 5.3 of Swift.
+
 ## How to use it
 
 Unfortunately Swift is not perfect in *reflection* (introspection) and a lot of settings we have to do manually. 
@@ -72,7 +74,7 @@ openAPIBuilder.add(
 
 Each controller can have list of actions (routes) with name, description, response and requests information.
 
-**Get by id action**
+**Get by id action (object in response)**
 
 ```swift
 APIAction(method: .get, route: "/users/{id}",
@@ -82,13 +84,24 @@ APIAction(method: .get, route: "/users/{id}",
         APIParameter(name: "id", description: "User id", required: true)
     ],
     responses: [
-        APIResponse(code: "200", description: "Specific user", object: UserDto.self),
+        APIResponse(code: "200", description: "Specific user", type: .object(UserDto.self),
         APIResponse(code: "404", description: "User with entered id not exists"),
         APIResponse(code: "401", description: "User not authorized")
     ],
     authorization: true
 )
+```
 
+**Get action (value type in response)**
+
+```swift
+APIAction(method: .get, route: "/version",
+    summary: "Getting system version",
+    description: "Action for getting application current version",
+    responses: [
+        APIResponse(code: "200", description: "Specific user", type: .value("1.0.0")
+    ]
+)
 ```
 
 **Post action**
@@ -99,8 +112,8 @@ APIAction(method: .post, route: "/users",
     description: "Action for adding new user to the server",
     request: APIRequest(object: userDto, description: "Object with user information."),
     responses: [
-        APIResponse(code: "200", description: "User data after adding to the system", object: UserDto.self),
-        APIResponse(code: "400", description: "There was issues during adding new user", object: ValidationErrorResponseDto.self),
+        APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
+        APIResponse(code: "400", description: "There was issues during adding new user", type: .object(ValidationErrorResponseDto.self)),
         APIResponse(code: "401", description: "User not authorized")
     ],
     authorization: true
@@ -137,7 +150,7 @@ let openAPIBuilder = OpenAPIBuilder(
             summary: "Getting all users",
             description: "Action for getting all users from server",
             responses: [
-                APIResponse(code: "200", description: "List of users", object: UserDto.self),
+                APIResponse(code: "200", description: "List of users", type: .object(UserDto.self)),
                 APIResponse(code: "401", description: "User not authorized")
             ],
             authorization: true
@@ -149,7 +162,7 @@ let openAPIBuilder = OpenAPIBuilder(
                 APIParameter(name: "id", description: "User id", required: true)
             ],
             responses: [
-                APIResponse(code: "200", description: "Specific user", object: UserDto.self),
+                APIResponse(code: "200", description: "Specific user", type: .object(UserDto.self)),
                 APIResponse(code: "404", description: "User with entered id not exists"),
                 APIResponse(code: "401", description: "User not authorized")
             ],
@@ -160,8 +173,8 @@ let openAPIBuilder = OpenAPIBuilder(
             description: "Action for adding new user to the server",
             request: APIRequest(object: UserDto.self, description: "Object with user information."),
             responses: [
-                APIResponse(code: "200", description: "User data after adding to the system", object: UserDto.self),
-                APIResponse(code: "400", description: "There was issues during adding new user", object: ValidationErrorResponseDto.self),
+                APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
+                APIResponse(code: "400", description: "There was issues during adding new user", type: .object(ValidationErrorResponseDto.self)),
                 APIResponse(code: "401", description: "User not authorized")
             ],
             authorization: true
@@ -174,8 +187,8 @@ let openAPIBuilder = OpenAPIBuilder(
             ],
             request: APIRequest(object: UserDto.self, description: "Object with user information."),
             responses: [
-                APIResponse(code: "200", description: "User data after adding to the system", object: UserDto.self),
-                APIResponse(code: "400", description: "There was issues during updating user", object: ValidationErrorResponseDto.self),
+                APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
+                APIResponse(code: "400", description: "There was issues during updating user", type: .object(ValidationErrorResponseDto.self)),
                 APIResponse(code: "404", description: "User with entered id not exists"),
                 APIResponse(code: "401", description: "User not authorized")
             ],
@@ -243,8 +256,8 @@ Command options are:
 ```
 
 **TODO:**
-[ ] Client services generation
-[ ] Infromation how to use generated HTTP client services
+ - [ ] Client services generation
+ - [ ] Infromation how to use generated HTTP client services
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ APIAction(method: .get, route: "/version",
 APIAction(method: .post, route: "/users",
     summary: "Adding new user",
     description: "Action for adding new user to the server",
-    request: APIRequest(object: userDto, description: "Object with user information."),
+    request: APIRequest(type: .object(UserDto.self), description: "Object with user information."),
     responses: [
         APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
         APIResponse(code: "400", description: "There was issues during adding new user", type: .object(ValidationErrorResponseDto.self)),
@@ -171,7 +171,7 @@ let openAPIBuilder = OpenAPIBuilder(
         APIAction(method: .post, route: "/users",
             summary: "Adding new user",
             description: "Action for adding new user to the server",
-            request: APIRequest(object: UserDto.self, description: "Object with user information."),
+            request: APIRequest(type: .object(UserDto.self), description: "Object with user information."),
             responses: [
                 APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
                 APIResponse(code: "400", description: "There was issues during adding new user", type: .object(ValidationErrorResponseDto.self)),
@@ -185,7 +185,7 @@ let openAPIBuilder = OpenAPIBuilder(
             parameters: [
                 APIParameter(name: "id", description: "User id", required: true)
             ],
-            request: APIRequest(object: UserDto.self, description: "Object with user information."),
+            request: APIRequest(type: .object(UserDto.self), description: "Object with user information."),
             responses: [
                 APIResponse(code: "200", description: "User data after adding to the system", type: .object(UserDto.self)),
                 APIResponse(code: "400", description: "There was issues during updating user", type: .object(ValidationErrorResponseDto.self)),

--- a/Sources/Swiftgger/APIModel/APIRequest.swift
+++ b/Sources/Swiftgger/APIModel/APIRequest.swift
@@ -9,12 +9,12 @@ import Foundation
 
 /// Information about HTTP request.
 public class APIRequest {
-    var object: Any.Type?
+    var type: APIResponseType?
     var description: String?
     var contentType: String?
 
-    public init(object: Any.Type? = nil, description: String? = nil, contentType: String? = nil) {
-        self.object = object
+    public init(type: APIResponseType? = nil, description: String? = nil, contentType: String? = nil) {
+        self.type = type
         self.description = description
         self.contentType = contentType
     }

--- a/Sources/Swiftgger/APIModel/APIResponse.swift
+++ b/Sources/Swiftgger/APIModel/APIResponse.swift
@@ -11,8 +11,7 @@ import Foundation
 public class APIResponse {
     var code: String
     var description: String
-    var object: Any.Type?
-    var array: Any.Type?
+    var type: APIResponseType?
     var contentType: String?
 
     public init(code: String, description: String) {
@@ -20,17 +19,10 @@ public class APIResponse {
         self.description = description
     }
 
-    public init(code: String, description: String, object: Any.Type?, contentType: String? = nil) {
+    public init(code: String, description: String, type: APIResponseType?, contentType: String? = nil) {
         self.code = code
         self.description = description
-        self.object = object
-        self.contentType = contentType
-    }
-
-    public init(code: String, description: String, array: Any.Type?, contentType: String? = nil) {
-        self.code = code
-        self.description = description
-        self.array = array
+        self.type = type
         self.contentType = contentType
     }
 }

--- a/Sources/Swiftgger/APIModel/APIResponseType.swift
+++ b/Sources/Swiftgger/APIModel/APIResponseType.swift
@@ -1,0 +1,11 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+/// Possible response types.
+public enum APIResponseType {
+    case object(Any.Type, asCollection: Bool = false)
+    case value(Any)
+}

--- a/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
@@ -20,13 +20,13 @@ class OpenAPIRequestBuilder {
 
     func built() -> OpenAPIRequestBody? {
 
-        guard let apiRequest = request, let apiRequestObject = apiRequest.object else {
+        guard let apiRequest = request, let apiRequestType = apiRequest.type else {
             return nil
         }
 
         let contentType = apiRequest.contentType ?? "application/json"
 
-        let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: .object(apiRequestObject))
+        let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: apiRequestType)
         let mediaType = openAPIMediaTypeBuilder.built()
 
         let requestBody = OpenAPIRequestBody(description: apiRequest.description, content: [contentType: mediaType])

--- a/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
@@ -26,7 +26,7 @@ class OpenAPIRequestBuilder {
 
         let contentType = apiRequest.contentType ?? "application/json"
 
-        let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: apiRequestObject)
+        let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: .object(apiRequestObject))
         let mediaType = openAPIMediaTypeBuilder.built()
 
         let requestBody = OpenAPIRequestBody(description: apiRequest.description, content: [contentType: mediaType])

--- a/Sources/Swiftgger/Builder/OpenAPIResponsesBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIResponsesBuilder.swift
@@ -27,22 +27,9 @@ class OpenAPIResponsesBuilder {
         var openAPIResponses: [String: OpenAPIResponse] = [:]
 
         for apiResponse in apiResponses {
-
-            var apiResponseObject: Any.Type?
-            var isArray: Bool = false
-
-            if apiResponse.object != nil {
-                apiResponseObject = apiResponse.object
-            } else if apiResponse.array != nil {
-                isArray = true
-                apiResponseObject = apiResponse.array
-            }
-
-            if apiResponseObject != nil {
-
+            if let apiResponseType = apiResponse.type {
                 let contentType = apiResponse.contentType ?? "application/json"
-
-                let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: apiResponseObject!, isArray: isArray)
+                let openAPIMediaTypeBuilder = OpenAPIMediaTypeBuilder(objects: objects, for: apiResponseType)
                 let mediaType = openAPIMediaTypeBuilder.built()
 
                 let openAPIResponse = OpenAPIResponse(

--- a/Sources/Swiftgger/Common/APIDataType.swift
+++ b/Sources/Swiftgger/Common/APIDataType.swift
@@ -11,7 +11,47 @@ import Foundation
 public struct APIDataType {
     let type: String
     let format: String?
+}
 
+extension APIDataType {
+    /// Infer OpenAPI Data Type from Swift value type
+    ///
+    /// - Parameter value: Swift property value to analyze
+    /// - Returns: Most appropriate OpenAPI Data Type
+    init?(fromSwiftValue value: Any) {
+        switch value {
+        case is Int32:
+            self.type = "integer"
+            self.format = "int32"
+        case is Int:
+            self.type = "integer"
+            self.format = "int64"
+        case is Float:
+            self.type = "number"
+            self.format = "float"
+        case is Double:
+            self.type = "number"
+            self.format = "double"
+        case is Bool:
+            self.type = "boolean"
+            self.format = nil
+        case is Date:
+            self.type = "string"
+            self.format = "date"
+        case is String:
+            self.type = "string"
+            self.format = nil
+        case is UUID:
+            self.type = "string"
+            self.format = "uuid"
+        default:
+            return nil
+        }
+    }
+}
+
+extension APIDataType {
+    public static let array = APIDataType(type: "array", format: nil)
     public static let int32 = APIDataType(type: "integer", format: "int32")
     public static let int64 = APIDataType(type: "integer", format: "int64")
     public static let float = APIDataType(type: "number", format: "float")

--- a/Sources/Swiftgger/Common/MirrorHelper.swift
+++ b/Sources/Swiftgger/Common/MirrorHelper.swift
@@ -1,0 +1,101 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski. All rights reserved.
+//
+    
+
+import Foundation
+
+class MirrorHelper {
+    static func getRequiredProperties(properties: Mirror.Children) -> [String] {
+        var array: [String] = []
+
+        for property in properties {
+            
+            // Eventually extract property from property wrapper.
+            let unwrappedProperty = self.getWrappedProperty(property: property)
+            
+            // Append to list of required non optional properties.
+            if !isOptional(unwrappedProperty.value) {
+                array.append(unwrappedProperty.label!)
+            }
+        }
+
+        return array
+    }
+
+    static func unwrap<T>(_ any: T) -> Any {
+
+        let mirror = Mirror(reflecting: any)
+        guard mirror.displayStyle == .optional, let first = mirror.children.first else {
+            return any
+        }
+
+        return first.value
+    }
+    
+    static func convertBasedOnValueType(_ any: Any) -> Any {
+        if let uuid = any as? UUID {
+            return uuid.uuidString
+        }
+        
+        return any
+    }
+
+    static func isOptional<T>(_ any: T) -> Bool {
+        let mirror = Mirror(reflecting: any)
+        return mirror.displayStyle == .optional
+    }
+    
+    static func isInitialized<T>(object any: T) -> Bool {
+        let mirror = Mirror(reflecting: any)
+
+        return mirror.displayStyle == .struct
+            || mirror.displayStyle == .class
+            || mirror.displayStyle == .enum
+    }
+    
+    static func getTypeName(from any: Any) -> String? {
+        let typeName = String(describing: type(of: any))
+        
+        let pattern = "^Optional<(?<type>\\w+)>$"
+        return self.match(pattern: pattern, in: typeName)
+    }
+
+    static func getArrayTypeName(from any: Any) -> String? {
+        let typeName = String(describing: type(of: any))
+        
+        let pattern = "^Optional<Array<(?<type>\\w+)>>$"
+        return self.match(pattern: pattern, in: typeName)
+    }
+    
+    static func getWrappedProperty(property: Mirror.Child) -> Mirror.Child {
+        let mirrored = Mirror(reflecting: property.value)
+        let propertyWrapped = mirrored.children.first { (child) -> Bool in
+            child.label == "wrappedValue"
+        }
+        
+        if let propertyUnwrapped = propertyWrapped {
+            let propertyLabel = property.label?.trimmingCharacters(in: CharacterSet.init(charactersIn: "_"))
+            return (label: propertyLabel, value: propertyUnwrapped.value)
+        }
+        
+        return property
+    }
+    
+    static func match(pattern: String, in text: String) -> String? {
+        let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+        if let match = regex?.firstMatch(in: text, options: [], range: NSRange(location: 0, length: text.utf8.count)) {
+            guard match.numberOfRanges == 2 else {
+                return nil
+            }
+            
+            if let typeRange = Range(match.range(at: 1), in: text) {
+                return String(text[typeRange])
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SwiftggerTestApp/Program.swift
+++ b/Sources/SwiftggerTestApp/Program.swift
@@ -41,11 +41,29 @@ class Program {
         ])
         .add(APIController(name: "VehiclesController", description: "Contoller for vehicles", actions: [
             APIAction(method: .get,
+                      route: "/version/ownername",
+                      summary: "Get vehicle owner name",
+                      description: "GET action for downloading vehicle owner name.",
+                      responses: [
+                        APIResponse(code: "200", description: "Vehicle owner name", type: .value("John doe"), contentType: "application/text"),
+                        APIResponse(code: "401", description: "Unauthorized")
+                      ]
+            ),
+            APIAction(method: .get,
+                      route: "/version/certificates",
+                      summary: "Get vehicle certificates",
+                      description: "GET action for downloading vehicle certificates.",
+                      responses: [
+                        APIResponse(code: "200", description: "Vehicle certificates", type: .value(["EURO 6", "ABS"]), contentType: "application/json"),
+                        APIResponse(code: "401", description: "Unauthorized")
+                      ]
+            ),
+            APIAction(method: .get,
                       route: "/vehicles",
                       summary: "Get list of vehicles",
                       description: "GET action for downloading list of vehicles.",
                       responses: [
-                        APIResponse(code: "200", description: "List of vehicles", array: Vehicle.self, contentType: "application/json"),
+                        APIResponse(code: "200", description: "List of vehicles", type: .object(Vehicle.self, asCollection: true), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized")
                       ]
             ),
@@ -57,7 +75,7 @@ class Program {
                         APIParameter(name: "id", description: "Vehicle id", required: true)
                       ],
                       responses: [
-                        APIResponse(code: "200", description: "List of vehicles", object: Vehicle.self, contentType: "application/json"),
+                        APIResponse(code: "200", description: "List of vehicles", type: .object(Vehicle.self), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized"),
                         APIResponse(code: "403", description: "Forbidden"),
                         APIResponse(code: "404", description: "NotFound")
@@ -69,7 +87,7 @@ class Program {
                       description: "POST action for creating new vehicle.",
                       request: APIRequest(object: Vehicle.self, description: "New vehicle", contentType: "application/json"),
                       responses: [
-                        APIResponse(code: "201", description: "Created vehicles", object: Vehicle.self, contentType: "application/json"),
+                        APIResponse(code: "201", description: "Created vehicles", type: .object(Vehicle.self), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized"),
                         APIResponse(code: "403", description: "Forbidden")
                       ]
@@ -83,7 +101,7 @@ class Program {
                       ],
                       request: APIRequest(object: Vehicle.self, description: "New vehicle", contentType: "application/json"),
                       responses: [
-                        APIResponse(code: "200", description: "Updated vehicles", object: Vehicle.self, contentType: "application/json"),
+                        APIResponse(code: "200", description: "Updated vehicles", type: .object(Vehicle.self), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized"),
                         APIResponse(code: "403", description: "Forbidden"),
                         APIResponse(code: "404", description: "NotFound")

--- a/Sources/SwiftggerTestApp/Program.swift
+++ b/Sources/SwiftggerTestApp/Program.swift
@@ -85,7 +85,7 @@ class Program {
                       route: "/vehicles",
                       summary: "Create new vehicle",
                       description: "POST action for creating new vehicle.",
-                      request: APIRequest(object: Vehicle.self, description: "New vehicle", contentType: "application/json"),
+                      request: APIRequest(type: .object(Vehicle.self), description: "New vehicle", contentType: "application/json"),
                       responses: [
                         APIResponse(code: "201", description: "Created vehicles", type: .object(Vehicle.self), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized"),
@@ -99,7 +99,7 @@ class Program {
                       parameters: [
                         APIParameter(name: "id", description: "Vehicle id", required: true)
                       ],
-                      request: APIRequest(object: Vehicle.self, description: "New vehicle", contentType: "application/json"),
+                      request: APIRequest(type: .object(Vehicle.self), description: "New vehicle", contentType: "application/json"),
                       responses: [
                         APIResponse(code: "200", description: "Updated vehicles", type: .object(Vehicle.self), contentType: "application/json"),
                         APIResponse(code: "401", description: "Unauthorized"),
@@ -121,6 +121,15 @@ class Program {
                         APIResponse(code: "404", description: "NotFound")
                       ],
                       authorization: true
+            ),
+            APIAction(method: .get,
+                      route: "/echo",
+                      summary: "Send text",
+                      description: "GET action for printing request in response body",
+                      request: APIRequest(type: .value("Hello world!"), description: "Echo text", contentType: "application/text"),
+                      responses: [
+                        APIResponse(code: "200", description: "List of vehicles", type: .value("(Response) Hello world!"), contentType: "application/text")
+                      ]
             )
         ]))
 

--- a/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
@@ -207,7 +207,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", object: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self))
                         ]
             )
         ]))
@@ -233,7 +233,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", object: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self))
                         ]
             )
         ]))
@@ -260,7 +260,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", object: Animal.self, contentType: "application/xml")
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self), contentType: "application/xml")
                         ]
             )
         ]))
@@ -287,7 +287,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", object: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self))
                         ]
             )
         ]))
@@ -314,7 +314,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", array: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self, asCollection: true))
                         ]
             )
         ]))
@@ -340,7 +340,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", object: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self))
                         ]
             )
         ]))
@@ -366,7 +366,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
                       description: "Action description", responses: [
-                          APIResponse(code: "200", description: "Response description", array: Animal.self)
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self, asCollection: true))
                         ]
             )
         ]))
@@ -563,14 +563,13 @@ class OpenAPIPathsBuilderTests: XCTestCase {
             title: "Title",
             version: "1.0.0",
             description: "Description"
-            )
-            .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
-                APIAction(method: .get, route: "/animals/{id}", summary: "Action summary", description: "Action description", parameters: [
-                    APIParameter(name: "id", parameterLocation: .path, description: "Parameter description",
-                                 required: true, deprecated: true, allowEmptyValue: true)
-                    ])
-                ])
         )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/animals/{id}", summary: "Action summary", description: "Action description", parameters: [
+                APIParameter(name: "id", parameterLocation: .path, description: "Parameter description",
+                             required: true, deprecated: true, allowEmptyValue: true)
+            ])
+        ]))
 
         // Act.
         let openAPIDocument = openAPIBuilder.built()
@@ -581,27 +580,129 @@ class OpenAPIPathsBuilderTests: XCTestCase {
 
     func testActionObjectResponseReferenceWithCustomNameShouldBeAddedToOpenAPIDocument() {
 
-      // Arrange.
-      let openAPIBuilder = OpenAPIBuilder(
-        title: "Title",
-        version: "1.0.0",
-        description: "Description"
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
-          APIAction(method: .get, route: "/animals", summary: "Action summary",
-                    description: "Action description", responses: [
-                      APIResponse(code: "200", description: "Response description", object: Animal.self)
-            ]
-          )
-          ]))
+            APIAction(method: .get, route: "/animals", summary: "Action summary",
+                      description: "Action description", responses: [
+                        APIResponse(code: "200", description: "Response description", type: .object(Animal.self))
+                      ]
+                     )
+        ]))
         .add([
-          APIObject(object: Animal(name: "Dog", age: 21), customName: "CustomAnimal")
-          ])
+            APIObject(object: Animal(name: "Dog", age: 21), customName: "CustomAnimal")
+        ])
 
-      // Act.
-      let openAPIDocument = openAPIBuilder.built()
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
 
-      // Assert.
-      XCTAssertEqual("#/components/schemas/CustomAnimal", openAPIDocument.paths["/animals"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.ref)
+        // Assert.
+        XCTAssertEqual("#/components/schemas/CustomAnimal", openAPIDocument.paths["/animals"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.ref)
+    }
+    
+    func testActionStringValueTypeResponseShouldBeAddedToOpenAPIDocument() {
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/version", summary: "Action summary",
+                      description: "Action description", responses: [
+                        APIResponse(code: "200", description: "Response description", type: .value("1.0.0"), contentType: "application/text")
+                      ]
+                     )
+        ]))
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("string", openAPIDocument.paths["/version"]?.get?.responses?["200"]?.content?["application/text"]?.schema?.type)
+        XCTAssertEqual("1.0.0", openAPIDocument.paths["/version"]?.get?.responses?["200"]?.content?["application/text"]?.schema?.example)
+    }
+    
+    func testActionStringArrayValueTypeResponseShouldBeAddedToOpenAPIDocument() {
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/certificates", summary: "Action summary",
+                      description: "Action description", responses: [
+                        APIResponse(code: "200", description: "Response description", type: .value(["EURO 6", "ABS"]), contentType: "application/json")
+                      ]
+                     )
+        ]))
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("array", openAPIDocument.paths["/certificates"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.type)
+        XCTAssertEqual("string", openAPIDocument.paths["/certificates"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.items?.type)
+        
+        let example = openAPIDocument.paths["/certificates"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.example?.value as? [String]
+        XCTAssertNotNil(example, "Example array not exists")
+        XCTAssertEqual("EURO 6", example![0])
+        XCTAssertEqual("ABS", example![1])
+    }
+    
+    func testActionNumberValueTypeResponseShouldBeAddedToOpenAPIDocument() {
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/temperature", summary: "Action summary",
+                      description: "Action description", responses: [
+                        APIResponse(code: "200", description: "Response description", type: .value(43.5), contentType: "application/text")
+                      ]
+                     )
+        ]))
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("number", openAPIDocument.paths["/temperature"]?.get?.responses?["200"]?.content?["application/text"]?.schema?.type)
+        XCTAssertEqual(43.5, openAPIDocument.paths["/temperature"]?.get?.responses?["200"]?.content?["application/text"]?.schema?.example)
+    }
+    
+    func testActionNumberArrayValueTypeResponseShouldBeAddedToOpenAPIDocument() {
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/temperature", summary: "Action summary",
+                      description: "Action description", responses: [
+                        APIResponse(code: "200", description: "Response description", type: .value([32.4, 42.1]), contentType: "application/json")
+                      ]
+                     )
+        ]))
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("array", openAPIDocument.paths["/temperature"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.type)
+        XCTAssertEqual("number", openAPIDocument.paths["/temperature"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.items?.type)
+        
+        let example = openAPIDocument.paths["/temperature"]?.get?.responses?["200"]?.content?["application/json"]?.schema?.example?.value as? [Double]
+        XCTAssertNotNil(example, "Example array not exists")
+        XCTAssertEqual(32.4, example![0])
+        XCTAssertEqual(42.1, example![1])
     }
 }

--- a/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
@@ -392,7 +392,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
-                      description: "Action description", request: APIRequest(object: Animal.self, description: "Animal request")
+                      description: "Action description", request: APIRequest(type: .object(Animal.self), description: "Animal request")
 
                 )
         ]))
@@ -418,7 +418,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
-                      description: "Action description", request: APIRequest(object: Animal.self, description: "Animal request")
+                      description: "Action description", request: APIRequest(type: .object(Animal.self), description: "Animal request")
 
             )
         ]))
@@ -444,7 +444,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
-                      description: "Action description", request: APIRequest(object: Animal.self, description: "Animal request", contentType: "application/xml")
+                      description: "Action description", request: APIRequest(type: .object(Animal.self), description: "Animal request", contentType: "application/xml")
 
             )
         ]))
@@ -470,7 +470,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
-                      description: "Action description", request: APIRequest(object: Animal.self, description: "Animal request")
+                      description: "Action description", request: APIRequest(type: .object(Animal.self), description: "Animal request")
 
             )
         ]))
@@ -495,7 +495,7 @@ class OpenAPIPathsBuilderTests: XCTestCase {
         )
         .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
             APIAction(method: .get, route: "/animals", summary: "Action summary",
-                      description: "Action description", request: APIRequest(object: Animal.self, description: "Animal request")
+                      description: "Action description", request: APIRequest(type: .object(Animal.self), description: "Animal request")
 
             )
         ]))
@@ -508,6 +508,32 @@ class OpenAPIPathsBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertEqual("#/components/schemas/Animal", openAPIDocument.paths["/animals"]?.get?.requestBody?.content?["application/json"]?.schema?.ref)
+    }
+    
+    func testActionRequestValueTypeShouldBeAddedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add(APIController(name: "ControllerName", description: "ControllerDescription", actions: [
+            APIAction(method: .get, route: "/animals", summary: "Action summary",
+                      description: "Action description", request: APIRequest(type: .value("Lion"), description: "Animal request")
+
+            )
+        ]))
+        .add([
+            APIObject(object: Animal(name: "Dog", age: 21))
+        ])
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertEqual("string", openAPIDocument.paths["/animals"]?.get?.requestBody?.content?["application/json"]?.schema?.type)
+        XCTAssertEqual("Lion", openAPIDocument.paths["/animals"]?.get?.requestBody?.content?["application/json"]?.schema?.example)
     }
 
     func testActionParameterNameShouldBeAddedToOpenAPIDocument() {


### PR DESCRIPTION
Only objects (JSON) were supported so far as request and response body. Support of simple value types has been added. Now we can specify value instead of object in `APIRequest` and `APIResponse` objects. For example:

```swift
// Request
APIRequest(type: .value("John Doe"), description: "Specify your full name")

// Response
APIResponse(code: "200", description: "Registered full name", type: .value("John Doe"))
```

## Breaking changes

This change requires from developers to change parameters in OpenAPI build process.

**Request**

```swift
// Old registration.
APIRequest(object: UserDto.self, description: "Object with user information.")

// New registration
APIRequest(type: .object(UserDto.self), description: "Object with user information.")
```

**Response**

```swift
// Old registration
APIResponse(code: "200", description: "Specific user", object: UserDto.self)

// New registration
APIResponse(code: "200", description: "Specific user", type: .object(UserDto.self))
```
