### PR TITLE
#21 Support examples for array properties

### DIFF
--- a/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
@@ -102,7 +102,7 @@ class OpenAPISchemasBuilder {
                         unwrapped: Any,
                         array: inout [(name: String, type: OpenAPISchema)]
     ) {
-        let exampleValue = MirrorHelper.convertBasedOnValueType(unwrapped)
+        let exampleValue = MirrorHelper.convert(valueType: unwrapped)
         let example = AnyCodable(exampleValue)
         let objectProperty = OpenAPISchema(type: dataType.type, format: dataType.format, example: example)
         array.append((name: property.label ?? "", type: objectProperty))
@@ -118,14 +118,16 @@ class OpenAPISchemasBuilder {
 
         let unwrapped = MirrorHelper.unwrap(item)
         if let dataType = APIDataType(fromSwiftValue: unwrapped) {
+            let exampleValue = MirrorHelper.convert(arrayType: items)
+            let example = AnyCodable(exampleValue)
             let openApiSchema = OpenAPISchema(type: dataType.type, format: dataType.format)
-            let objectProperty = OpenAPISchema(items: openApiSchema)
+            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema, example: example)
 
             array.append((name: property.label ?? "", type: objectProperty))
         } else {
             let typeName = String(describing: type(of: item))
             let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-            let objectProperty = OpenAPISchema(items: openApiSchema)
+            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
 
             array.append((name: property.label ?? "", type: objectProperty))
             self.nestedObjects.append(item)
@@ -181,7 +183,7 @@ class OpenAPISchemasBuilder {
                         array: inout [(name: String, type: OpenAPISchema)]
     ) {
         let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(arrayName)")
-        let objectProperty = OpenAPISchema(items: openApiSchema)
+        let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
         array.append((name: property.label ?? "", type: objectProperty))
     }
 }

--- a/Sources/Swiftgger/Common/MirrorHelper.swift
+++ b/Sources/Swiftgger/Common/MirrorHelper.swift
@@ -34,9 +34,17 @@ class MirrorHelper {
         return first.value
     }
     
-    static func convertBasedOnValueType(_ any: Any) -> Any {
+    static func convert(valueType any: Any) -> Any {
         if let uuid = any as? UUID {
             return uuid.uuidString
+        }
+        
+        return any
+    }
+    
+    static func convert(arrayType any: Any) -> Any {
+        if let uuidArray = any as? [UUID] {
+            return uuidArray.map { uuid in uuid.uuidString }
         }
         
         return any

--- a/Sources/SwiftggerTestApp/Program.swift
+++ b/Sources/SwiftggerTestApp/Program.swift
@@ -33,11 +33,11 @@ class Program {
                                       hasEngine: false,
                                       tags: ["key": "value"],
                                       dictionary: [
-                                        "somethinf" : Fuel(level: 1, type: "GAS", productionDate: Date(), parameters: ["power"])
+                                        "somethinf" : Fuel(level: 1, type: "GAS", productionDate: Date(), parameters: ["power", "speed"])
                                       ],
                                       keyId: UUID(),
                                       uuidIds: [UUID(), UUID(), UUID()])),
-            APIObject(object: Fuel(level: 90, type: "GAS", productionDate: Date(), parameters: ["power"]))
+            APIObject(object: Fuel(level: 90, type: "GAS", productionDate: Date(), parameters: ["power", "speed"]))
         ])
         .add(APIController(name: "VehiclesController", description: "Contoller for vehicles", actions: [
             APIAction(method: .get,

--- a/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
@@ -315,6 +315,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"], "Vehicle schema not exists")
+        XCTAssertEqual("array", openAPIDocument.components?.schemas?["User"]?.properties?["vehicles"]?.type)
         XCTAssertEqual("#/components/schemas/Vehicle", openAPIDocument.components?.schemas?["User"]?.properties?["vehicles"]?.items?.ref)
     }
 
@@ -352,6 +353,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
+        XCTAssertEqual("array", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.type)
         XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.items?.ref)
     }
     
@@ -391,6 +393,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
+        XCTAssertEqual("array", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.type)
         XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.items?.ref)
     }
     
@@ -444,7 +447,7 @@ class OpenAPISchemasBuilderTests: XCTestCase {
             description: "Description"
         )
         .add([
-            APIObject(object: Fuel(level: 1, type: "", parameters: ["power"]))
+            APIObject(object: Fuel(level: 1, type: "", parameters: ["power", "speed"]))
         ])
         
         // Act.
@@ -452,7 +455,13 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
+        XCTAssertEqual("array", openAPIDocument.components?.schemas?["Fuel"]?.properties?["parameters"]?.type)
         XCTAssertEqual("string", openAPIDocument.components?.schemas?["Fuel"]?.properties?["parameters"]?.items?.type)
+        
+        let example = openAPIDocument.components?.schemas?["Fuel"]?.properties?["parameters"]?.example?.value as? [String]
+        XCTAssertNotNil(example, "Example array not exists")
+        XCTAssertEqual("power", example![0])
+        XCTAssertEqual("speed", example![1])
     }
     
     func testSchemaWithDictionaryOfStringShouldBeTranslatedToOpenAPIDocument() {
@@ -517,5 +526,34 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         XCTAssertEqual("string", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["singleId"]?.type)
         XCTAssertEqual("uuid", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["singleId"]?.format)
         XCTAssertEqual("E621E1F8-C36C-495A-93FC-0C247A3E6E5F", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["singleId"]?.example)
+    }
+    
+    func testSchemaWithArrayOfUUIDProperyShouldBeTranslatedToOpenApiDocument() {
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add([
+            APIObject(object: VehicleKeys(singleId: UUID(), arrayIds: [
+                UUID(uuidString: "CE30476C-B335-41A8-9E68-1C0C98DCEB60")!,
+                UUID(uuidString: "B5728916-CD90-4A88-ABFD-23576BA563DA")!
+            ]))
+        ])
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["VehicleKeys"], "VehicleKeys schema not exists")
+        XCTAssertEqual("array", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["arrayIds"]?.type)
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["arrayIds"]?.items?.type)
+        XCTAssertEqual("uuid", openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["arrayIds"]?.items?.format)
+        
+        let example = openAPIDocument.components?.schemas?["VehicleKeys"]?.properties?["arrayIds"]?.example?.value as? [String]
+        XCTAssertNotNil(example, "Example array not exists")
+        XCTAssertEqual("CE30476C-B335-41A8-9E68-1C0C98DCEB60", example![0])
+        XCTAssertEqual("B5728916-CD90-4A88-ABFD-23576BA563DA", example![1])
     }
 }


### PR DESCRIPTION
Array properties are now properly transferred into example section of OpenAPI standard.