### PR TITLE
Support for coding keys support and key encoding strategy

### DIFF
--- a/Sources/Swiftgger/APIModel/APIObject.swift
+++ b/Sources/Swiftgger/APIModel/APIObject.swift
@@ -6,13 +6,21 @@
 
 import Foundation
 
-/// Information about (request/response) Swift object.
-public class APIObject {
-    let object: Any
-    let defaultName: String
-    let customName: String?
+public protocol APIObjectProtocol {
+    var anyObject: Any { get }
+    var defaultName: String { get }
+    var customName: String? { get }
+}
 
-    public init(object: Any, customName: String? = nil) {
+/// Information about (request/response) Swift object.
+public class APIObject<T: Encodable>: APIObjectProtocol {
+    public let object: T
+    public let defaultName: String
+    public let customName: String?
+
+    public var anyObject: Any { return object as Any }
+    
+    public init(object: T, customName: String? = nil) {
         self.object = object
         self.customName = customName
         self.defaultName = String(describing: type(of: object))

--- a/Sources/Swiftgger/APIModel/APIObjectEncodable.swift
+++ b/Sources/Swiftgger/APIModel/APIObjectEncodable.swift
@@ -6,12 +6,6 @@
     
 import Foundation
 
-extension Encodable {
-    fileprivate func openedEncode(to container: inout SingleValueEncodingContainer) throws {
-        try container.encode(self)
-    }
-}
-
 struct APIObjectEncodable : Encodable {
     var value: Encodable
     

--- a/Sources/Swiftgger/APIModel/APIObjectEncodable.swift
+++ b/Sources/Swiftgger/APIModel/APIObjectEncodable.swift
@@ -1,0 +1,26 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+    
+import Foundation
+
+extension Encodable {
+    fileprivate func openedEncode(to container: inout SingleValueEncodingContainer) throws {
+        try container.encode(self)
+    }
+}
+
+struct APIObjectEncodable : Encodable {
+    var value: Encodable
+    
+    init(_ value: Encodable) {
+        self.value = value
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try value.openedEncode(to: &container)
+    }
+}

--- a/Sources/Swiftgger/Builder/OpenAPIBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIBuilder.swift
@@ -19,7 +19,7 @@ public class OpenAPIBuilder {
 
     var controllers: [APIController] = []
     var servers: [APIServer] = []
-    var objects: [APIObject] = []
+    var objects: [APIObjectProtocol] = []
 
     /**
         Initializes a instance of OpenAPI documentation builder.
@@ -83,7 +83,7 @@ public class OpenAPIBuilder {
 
         - Returns: Same OpenAPI builder.
     */
-    public func add(_ objects: [APIObject]) -> OpenAPIBuilder {
+    public func add(_ objects: [APIObjectProtocol]) -> OpenAPIBuilder {
         self.objects.append(contentsOf: objects)
         return self
     }

--- a/Sources/Swiftgger/Builder/OpenAPIBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIBuilder.swift
@@ -21,6 +21,9 @@ public class OpenAPIBuilder {
     var servers: [APIServer] = []
     var objects: [APIObjectProtocol] = []
 
+    /// The strategy to use for encoding keys. Defaults to `.useDefaultKeys`.
+    var keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys
+    
     /**
         Initializes a instance of OpenAPI documentation builder.
 
@@ -89,6 +92,18 @@ public class OpenAPIBuilder {
     }
 
     /**
+        Use custom model key encoding strategy.
+     
+        - Parameter keyEncodingStrategy: Encoding key strategy used to prepare keys in OpenAPI model.
+
+        - Returns: Same OpenAPI builder.
+     */
+    public func use(keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy) -> OpenAPIBuilder {
+        self.keyEncodingStrategy = keyEncodingStrategy
+        return self
+    }
+    
+    /**
         Method which is responsible for build OpenAPI document.
 
         - Returns: Object with OpenAPI specification.
@@ -117,7 +132,7 @@ public class OpenAPIBuilder {
         let openAPIServers = openAPIServersBuilder.built()
 
         // Create information about schemas (objects).
-        let openAPISchemasBuilder = OpenAPISchemasBuilder(objects: self.objects)
+        let openAPISchemasBuilder = OpenAPISchemasBuilder(objects: self.objects, keyEncodingStrategy: self.keyEncodingStrategy)
         let schemas = openAPISchemasBuilder.built()
 
         // Create information about paths (actions).

--- a/Sources/Swiftgger/Builder/OpenAPIMediaTypeBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIMediaTypeBuilder.swift
@@ -9,10 +9,10 @@ import AnyCodable
 
 /// Builder of `paths` part of OpenAPI.
 class OpenAPIMediaTypeBuilder {
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
     let type: APIResponseType
 
-    init(objects: [APIObject], for type: APIResponseType) {
+    init(objects: [APIObjectProtocol], for type: APIResponseType) {
         self.objects = objects
         self.type = type
     }

--- a/Sources/Swiftgger/Builder/OpenAPIOperationBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIOperationBuilder.swift
@@ -12,9 +12,9 @@ class OpenAPIOperationBuilder {
     let controllerName: String
     let action: APIAction
     let authorizations: [APIAuthorizationType]?
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
 
-    init(controllerName: String, action: APIAction, authorizations: [APIAuthorizationType]?, objects: [APIObject]) {
+    init(controllerName: String, action: APIAction, authorizations: [APIAuthorizationType]?, objects: [APIObjectProtocol]) {
         self.controllerName = controllerName
         self.action = action
         self.authorizations = authorizations

--- a/Sources/Swiftgger/Builder/OpenAPIPathsBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIPathsBuilder.swift
@@ -10,9 +10,9 @@ import Foundation
 class OpenAPIPathsBuilder {
     let controllers: [APIController]
     let authorizations: [APIAuthorizationType]?
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
 
-    init(controllers: [APIController], authorizations: [APIAuthorizationType]?, objects: [APIObject]) {
+    init(controllers: [APIController], authorizations: [APIAuthorizationType]?, objects: [APIObjectProtocol]) {
         self.controllers = controllers
         self.authorizations = authorizations
         self.objects = objects

--- a/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIRequestBuilder.swift
@@ -10,9 +10,9 @@ import Foundation
 class OpenAPIRequestBuilder {
 
     let request: APIRequest?
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
 
-    init(request: APIRequest?, objects: [APIObject]) {
+    init(request: APIRequest?, objects: [APIObjectProtocol]) {
         self.request = request
         self.objects = objects
     }

--- a/Sources/Swiftgger/Builder/OpenAPIResponsesBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPIResponsesBuilder.swift
@@ -10,9 +10,9 @@ import Foundation
 class OpenAPIResponsesBuilder {
 
     let responses: [APIResponse]?
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
 
-    init(responses: [APIResponse]?, objects: [APIObject]) {
+    init(responses: [APIResponse]?, objects: [APIObjectProtocol]) {
         self.responses = responses
         self.objects = objects
     }

--- a/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
@@ -11,10 +11,13 @@ import AnyCodable
 class OpenAPISchemasBuilder {
 
     let objects: [APIObjectProtocol]
+    let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
+
     private var nestedObjects: [Any] = []
 
-    init(objects: [APIObjectProtocol]) {
+    init(objects: [APIObjectProtocol], keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy) {
         self.objects = objects
+        self.keyEncodingStrategy = keyEncodingStrategy
     }
 
     func built() -> [String: OpenAPISchema] {
@@ -27,7 +30,7 @@ class OpenAPISchemasBuilder {
                 continue
             }
             
-            let openAPISchemaConverter = OpenAPISchemaConverter()
+            let openAPISchemaConverter = OpenAPISchemaConverter(keyEncodingStrategy: self.keyEncodingStrategy)
             let objectSchema = openAPISchemaConverter.convert(APIObjectEncodable(anyEncodable), referencedObjects: objectsNames)
 
             let requestMirror: Mirror = Mirror(reflecting: object.anyObject)

--- a/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
+++ b/Sources/Swiftgger/Builder/OpenAPISchemasBuilder.swift
@@ -10,179 +10,35 @@ import AnyCodable
 /// Builder for object information stored in `components/schemas` part of OpenAPI.
 class OpenAPISchemasBuilder {
 
-    let objects: [APIObject]
+    let objects: [APIObjectProtocol]
     private var nestedObjects: [Any] = []
 
-    init(objects: [APIObject]) {
+    init(objects: [APIObjectProtocol]) {
         self.objects = objects
     }
 
     func built() -> [String: OpenAPISchema] {
 
         var schemas: [String: OpenAPISchema] = [:]
+        let objectsNames = self.objects.map { object in String(describing: type(of: object.anyObject)) }
+        
         for object in self.objects {
-            add(object: object.object, withCustomName: object.customName, toSchemas: &schemas)
-        }
+            guard let anyEncodable = object.anyObject as? Encodable else {
+                continue
+            }
+            
+            let openAPISchemaConverter = OpenAPISchemaConverter()
+            let objectSchema = openAPISchemaConverter.convert(APIObjectEncodable(anyEncodable), referencedObjects: objectsNames)
 
-        for nestedObject in self.nestedObjects {
-            add(object: nestedObject, withCustomName: nil, toSchemas: &schemas)
+            let requestMirror: Mirror = Mirror(reflecting: object.anyObject)
+            let mirrorObjectType = object.customName ?? String(describing: requestMirror.subjectType)
+
+            if schemas[mirrorObjectType] == nil {
+                let requestSchema = OpenAPISchema(type: "object", required: [], properties: objectSchema)
+                schemas[mirrorObjectType] = requestSchema
+            }
         }
 
         return schemas
-    }
-
-  private func add(object: Any, withCustomName customName: String?, toSchemas schemas: inout [String: OpenAPISchema]) {
-        let requestMirror: Mirror = Mirror(reflecting: object)
-        let mirrorObjectType = customName ?? String(describing: requestMirror.subjectType)
-
-        if schemas[mirrorObjectType] == nil {
-            let required = MirrorHelper.getRequiredProperties(properties: requestMirror.children)
-            let properties = self.getAllProperties(properties: requestMirror.children)
-            let requestSchema = OpenAPISchema(type: "object", required: required, properties: properties)
-            schemas[mirrorObjectType] = requestSchema
-        }
-    }
-
-    private func getAllProperties(properties: Mirror.Children) -> [(name: String, type: OpenAPISchema)] {
-        var array:  [(name: String, type: OpenAPISchema)] = []
-        for property in properties {
-            
-            // Eventually extract property from property wrapper.
-            let unwrappedProperty = MirrorHelper.getWrappedProperty(property: property)
-            
-            // Append property with correct type to array.
-            self.appendProperty(property: unwrappedProperty, array: &array)
-        }
-
-        return array
-    }
-    
-    private func appendProperty(property: Mirror.Child, array: inout [(name: String, type: OpenAPISchema)]) {
-
-        // Simple value type (also unwrapped optionals).
-        let unwrapped = MirrorHelper.unwrap(property.value)
-        if let dataType = APIDataType(fromSwiftValue: unwrapped) {
-            self.append(dataType: dataType, property: property, unwrapped: unwrapped, array: &array)
-            return
-        }
-        
-        // Non optional or initialized array (array which contains any data).
-        if let items = property.value as? Array<Any> {
-            self.append(items: items, property: property, array: &array)
-            return
-        }
-        
-        if let items = property.value as? Dictionary<String, Any> {
-            self.append(dictionary: items, property: property, array: &array)
-            return
-        }
-        
-        // Non optional or initialized object.
-        if MirrorHelper.isInitialized(object: unwrapped) {
-            self.append(reference: property, array: &array)
-            return
-        }
-        
-        // Optional and not initialized object.
-        if let typeName = MirrorHelper.getTypeName(from: unwrapped) {
-            self.append(typeName: typeName, property: property, array: &array)
-            return
-        }
-        
-        // Optional and not initialized arrays.
-        if let typeName = MirrorHelper.getArrayTypeName(from: unwrapped) {
-            self.append(arrayName: typeName, property: property, array: &array)
-            return
-        }
-    }
-
-    private func append(dataType: APIDataType,
-                        property: Mirror.Child,
-                        unwrapped: Any,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-        let exampleValue = MirrorHelper.convert(valueType: unwrapped)
-        let example = AnyCodable(exampleValue)
-        let objectProperty = OpenAPISchema(type: dataType.type, format: dataType.format, example: example)
-        array.append((name: property.label ?? "", type: objectProperty))
-    }
-
-    private func append(items: Array<Any>,
-                        property: Mirror.Child,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-        guard let item = items.first else {
-            return
-        }
-
-        let unwrapped = MirrorHelper.unwrap(item)
-        if let dataType = APIDataType(fromSwiftValue: unwrapped) {
-            let exampleValue = MirrorHelper.convert(arrayType: items)
-            let example = AnyCodable(exampleValue)
-            let openApiSchema = OpenAPISchema(type: dataType.type, format: dataType.format)
-            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema, example: example)
-
-            array.append((name: property.label ?? "", type: objectProperty))
-        } else {
-            let typeName = String(describing: type(of: item))
-            let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
-
-            array.append((name: property.label ?? "", type: objectProperty))
-            self.nestedObjects.append(item)
-        }
-    }
-    
-    private func append(dictionary: Dictionary<String, Any>,
-                        property: Mirror.Child,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-        guard let item = dictionary.first else {
-            return
-        }
-        
-        let unwrapped = MirrorHelper.unwrap(item.value)
-        if let dataType = APIDataType(fromSwiftValue: unwrapped) {
-            let additionalProperties = OpenAPISchema(type: dataType.type, format: dataType.format)
-            let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
-
-            array.append((name: property.label ?? "", type: objectProperty))
-        } else {
-            let typeName = String(describing: type(of: item.value))
-            let additionalProperties = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-            let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
-
-            array.append((name: property.label ?? "", type: objectProperty))
-            self.nestedObjects.append(item.value)
-        }
-    }
-
-    private func append(reference: Mirror.Child,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-        let unwrapped = MirrorHelper.unwrap(reference.value)
-        let typeName = String(describing: type(of: unwrapped))
-        let objectProperty = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-        array.append((name: reference.label ?? "", type: objectProperty))
-
-        self.nestedObjects.append(unwrapped)
-    }
-    
-    private func append(typeName: String,
-                        property: Mirror.Child,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-
-        let objectProperty = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-        array.append((name: property.label ?? "", type: objectProperty))
-    }
-    
-    private func append(arrayName: String,
-                        property: Mirror.Child,
-                        array: inout [(name: String, type: OpenAPISchema)]
-    ) {
-        let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(arrayName)")
-        let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
-        array.append((name: property.label ?? "", type: objectProperty))
     }
 }

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaConverter.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaConverter.swift
@@ -4,9 +4,18 @@
 //  Licensed under the MIT License.
 //
 
+import Foundation
+
 class OpenAPISchemaConverter {
-    open func convert<T : Encodable>(_ value: T, referencedObjects: [String]) -> [String: OpenAPISchema] {
-        let encoder = OpenAPISchemaEncoder(referencedObjects: referencedObjects)
+    let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
+    
+    init(keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy) {
+        self.keyEncodingStrategy = keyEncodingStrategy
+    }
+    
+    func convert<T : Encodable>(_ value: T, referencedObjects: [String]) -> [String: OpenAPISchema] {
+        let encoder = OpenAPISchemaEncoder(referencedObjects: referencedObjects,
+                                           keyEncodingStrategy: self.keyEncodingStrategy)
 
         guard let schema = try? encoder.process(value) else {
             return [:]

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaConverter.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaConverter.swift
@@ -1,0 +1,17 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+class OpenAPISchemaConverter {
+    open func convert<T : Encodable>(_ value: T, referencedObjects: [String]) -> [String: OpenAPISchema] {
+        let encoder = OpenAPISchemaEncoder(referencedObjects: referencedObjects)
+
+        guard let schema = try? encoder.process(value) else {
+            return [:]
+        }
+
+        return schema
+    }
+}

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaEncoder.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaEncoder.swift
@@ -1,0 +1,110 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AnyCodable
+
+class OpenAPISchemaEncoder: Encoder {
+    let userInfo: [CodingUserInfoKey : Any]
+    let codingPath: [CodingKey]
+    let storage: OpenAPISchemaStorage
+    let referencedObjects: [String]
+    
+    init(codingPath: [CodingKey] = [], referencedObjects: [String] = []) {
+        self.userInfo = [:]
+        self.codingPath = codingPath
+        self.referencedObjects = referencedObjects
+        self.storage = OpenAPISchemaStorage()
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        let container = OpenAPISchemaKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: storage)
+        return KeyedEncodingContainer(container)
+    }
+    
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath)
+    }
+    
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+    
+    func process(_ value: Encodable) throws -> [String: OpenAPISchema] {
+        try value.encode(to: self)
+        return self.storage.container
+    }
+}
+
+extension OpenAPISchemaEncoder : SingleValueEncodingContainer {
+    public func encodeNil() throws {
+        print("(OpenAPISchemaEncoder) Not supported encodeNil()")
+    }
+
+    public func encode(_ value: Bool) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.boolean.type, format: APIDataType.boolean.format, example: AnyCodable(value)))
+    }
+
+    public func encode(_ value: Int) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: Int8) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+
+    public func encode(_ value: Int16) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: Int32) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: Int64) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
+    }
+
+    public func encode(_ value: UInt) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: UInt8) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: UInt16) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: UInt32) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: UInt64) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: String) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.string.type, format: APIDataType.string.format, example: AnyCodable(value)))
+    }
+
+    public func encode(_ value: Float) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.float.type, format: APIDataType.float.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: Double) throws {
+        self.storage.push(parameter: OpenAPISchema(type: APIDataType.double.type, format: APIDataType.double.format, example: AnyCodable(value)))
+    }
+    
+    public func encode(_ value: IndexSet) throws {
+        print("(OpenAPISchemaEncoder) Not supported encode(IndexSet)")
+    }
+
+    public func encode<T : Encodable>(_ value: T) throws {
+        try value.encode(to: self)
+    }
+}

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaEncoder.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaEncoder.swift
@@ -12,21 +12,28 @@ class OpenAPISchemaEncoder: Encoder {
     let codingPath: [CodingKey]
     let storage: OpenAPISchemaStorage
     let referencedObjects: [String]
+    let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
     
-    init(codingPath: [CodingKey] = [], referencedObjects: [String] = []) {
+    init(codingPath: [CodingKey] = [], referencedObjects: [String] = [], keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy) {
         self.userInfo = [:]
         self.codingPath = codingPath
         self.referencedObjects = referencedObjects
+        self.keyEncodingStrategy = keyEncodingStrategy
         self.storage = OpenAPISchemaStorage()
     }
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        let container = OpenAPISchemaKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: storage)
+        let container = OpenAPISchemaKeyedEncodingContainer<Key>(referencing: self,
+                                                                 codingPath: self.codingPath,
+                                                                 wrapping: storage,
+                                                                 keyEncodingStrategy: self.keyEncodingStrategy)
         return KeyedEncodingContainer(container)
     }
     
     func unkeyedContainer() -> UnkeyedEncodingContainer {
-        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath)
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self,
+                                                     codingPath: self.codingPath,
+                                                     keyEncodingStrategy: self.keyEncodingStrategy)
     }
     
     func singleValueContainer() -> SingleValueEncodingContainer {

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaKeyedEncodingContainer.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaKeyedEncodingContainer.swift
@@ -1,0 +1,243 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AnyCodable
+
+class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContainerProtocol {
+    let encoder: OpenAPISchemaEncoder
+    var codingPath: [CodingKey]
+    var storage: OpenAPISchemaStorage
+    
+    init(referencing encoder: OpenAPISchemaEncoder, codingPath: [CodingKey], wrapping storage: OpenAPISchemaStorage) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.storage = storage
+    }
+    
+    func encodeNil(forKey key: Key) throws {
+        print("(OpenAPISchemaKeyedEncodingContainer) Not supported encodeNil()")
+    }
+    
+    func encode(_ value: Bool, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.boolean.type, format: APIDataType.boolean.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: String, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.string.type, format: APIDataType.string.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Double, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.double.type, format: APIDataType.double.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Float, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.float.type, format: APIDataType.float.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Int, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Int8, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Int16, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Int32, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: Int64, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: UInt, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: UInt8, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: UInt16, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: UInt32, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
+    }
+    
+    func encode(_ value: UInt64, forKey key: Key) throws {
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
+    }
+    
+    func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        // Collections.
+        if let items = value as? Array<Any> {
+            self.append(items: items, forKey: key)
+            return
+        }
+        
+        // Dictionaries.
+        if let items = value as? Dictionary<String, Any> {
+            self.append(dictionary: items, forKey: key)
+            return
+        }
+        
+        // Date.
+        if let date = value as? Date {
+            self.append(date: date, forKey: key)
+            return
+        }
+        
+        // UUID.
+        if let uuid = value as? UUID {
+            self.append(uuid: uuid, forKey: key)
+            return
+        }
+        
+        // Referenced object.
+        if self.isTypeReferenced(value) {
+            self.append(reference: value, forKey: key)
+            return
+        }
+        
+        // Unknown objects (also property wrappers).
+        self.append(complex: value, forKey: key)
+    }
+    
+    private func append(items: Array<Any>, forKey key: Key) {
+        guard let item = items.first else {
+            return
+        }
+
+        let unwrapped = MirrorHelper.unwrap(item)
+        if let dataType = APIDataType(fromSwiftValue: unwrapped) {
+            let exampleValue = MirrorHelper.convert(arrayType: items)
+            let example = AnyCodable(exampleValue)
+            let openApiSchema = OpenAPISchema(type: dataType.type, format: dataType.format)
+            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema, example: example)
+
+            storage.push(property: key.stringValue, withParameters: objectProperty)
+            
+        } else {
+            guard self.isTypeReferenced(item) else {
+                return
+            }
+            
+            let typeName = String(describing: type(of: item))
+            let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
+            let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
+            storage.push(property: key.stringValue, withParameters: objectProperty)
+        }
+    }
+    
+    private func append(dictionary: Dictionary<String, Any>, forKey key: Key) {
+        guard let item = dictionary.first else {
+            return
+        }
+        
+        let unwrapped = MirrorHelper.unwrap(item.value)
+        if let dataType = APIDataType(fromSwiftValue: unwrapped) {
+            let additionalProperties = OpenAPISchema(type: dataType.type, format: dataType.format)
+            let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
+
+            storage.push(property: key.stringValue, withParameters: objectProperty)
+        } else {
+            guard self.isTypeReferenced(item.value) else {
+                return
+            }
+            
+            let typeName = String(describing: type(of: item.value))
+            let additionalProperties = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
+            let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
+            storage.push(property: key.stringValue, withParameters: objectProperty)
+        }
+    }
+        
+    private func append<T>(reference value: T, forKey key: Key) where T : Encodable {
+        guard self.isTypeReferenced(value) else {
+            return
+        }
+        
+        let typeName = String(describing: type(of: value))
+        let objectProperty = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
+        storage.push(property: key.stringValue, withParameters: objectProperty)
+    }
+    
+    private func append(uuid: UUID, forKey key: Key) {
+        let objectProperty = OpenAPISchema(type: APIDataType.uuid.type, format: APIDataType.uuid.format, example: AnyCodable(uuid.uuidString))
+        storage.push(property: key.stringValue, withParameters: objectProperty)
+    }
+    
+    private func append(date: Date, forKey key: Key) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        let dateString = dateFormatter.string(from: date)
+        
+        storage.push(property: key.stringValue,
+                     withParameters: OpenAPISchema(type: APIDataType.dateTime.type, format: APIDataType.dateTime.format, example: AnyCodable(dateString)))
+    }
+    
+    private func append<T>(complex value: T, forKey key: Key) where T : Encodable {
+        
+        let internalEncoder = OpenAPISchemaEncoder(codingPath: [], referencedObjects: self.encoder.referencedObjects)
+        try? value.encode(to: internalEncoder)
+        
+        // Encode simple values (e.g. property wrappers simple values).
+        if let schemaItem = internalEncoder.storage.collection.first {
+            storage.push(property: key.stringValue, withParameters: schemaItem)
+            return
+        }
+        
+        // Encode complex objects.
+        if internalEncoder.storage.container.isEmpty == false {
+            let objectProperty = OpenAPISchema(type: "object", properties: internalEncoder.storage.container)
+            storage.push(property: key.stringValue, withParameters: objectProperty)
+        }
+    }
+    
+    private func isTypeReferenced(_ value: Any) -> Bool {
+        let typeName = String(describing: type(of: value))
+        return self.encoder.referencedObjects.contains(where: { referencedObject in referencedObject == typeName })
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: codingPath, wrapping: storage)
+        return KeyedEncodingContainer(container)
+    }
+    
+    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath)
+    }
+    
+    func superEncoder() -> Encoder {
+        return self.encoder
+    }
+    
+    func superEncoder(forKey key: Key) -> Encoder {
+        return self.encoder
+    }
+}

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaKeyedEncodingContainer.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaKeyedEncodingContainer.swift
@@ -9,13 +9,41 @@ import AnyCodable
 
 class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContainerProtocol {
     let encoder: OpenAPISchemaEncoder
+    let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
     var codingPath: [CodingKey]
     var storage: OpenAPISchemaStorage
     
-    init(referencing encoder: OpenAPISchemaEncoder, codingPath: [CodingKey], wrapping storage: OpenAPISchemaStorage) {
+    init(referencing encoder: OpenAPISchemaEncoder,
+         codingPath: [CodingKey],
+         wrapping storage: OpenAPISchemaStorage,
+         keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
+    ) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.storage = storage
+        self.keyEncodingStrategy = keyEncodingStrategy
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder,
+                                                                       codingPath: codingPath,
+                                                                       wrapping: storage,
+                                                                       keyEncodingStrategy: self.keyEncodingStrategy)
+        return KeyedEncodingContainer(container)
+    }
+    
+    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: encoder,
+                                                     codingPath: codingPath,
+                                                     keyEncodingStrategy: self.keyEncodingStrategy)
+    }
+    
+    func superEncoder() -> Encoder {
+        return self.encoder
+    }
+    
+    func superEncoder(forKey key: Key) -> Encoder {
+        return self.encoder
     }
     
     func encodeNil(forKey key: Key) throws {
@@ -23,72 +51,72 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
     }
     
     func encode(_ value: Bool, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.boolean.type, format: APIDataType.boolean.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: String, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.string.type, format: APIDataType.string.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Double, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.double.type, format: APIDataType.double.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Float, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.float.type, format: APIDataType.float.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Int, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Int8, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Int16, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Int32, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: Int64, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: UInt, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: UInt8, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: UInt16, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: UInt32, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int32.type, format: APIDataType.int32.format, example: AnyCodable(value)))
     }
     
     func encode(_ value: UInt64, forKey key: Key) throws {
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.int64.type, format: APIDataType.int64.format, example: AnyCodable(value)))
     }
     
@@ -139,7 +167,7 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
             let openApiSchema = OpenAPISchema(type: dataType.type, format: dataType.format)
             let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema, example: example)
 
-            storage.push(property: key.stringValue, withParameters: objectProperty)
+            storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
             
         } else {
             guard self.isTypeReferenced(item) else {
@@ -149,7 +177,7 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
             let typeName = String(describing: type(of: item))
             let openApiSchema = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
             let objectProperty = OpenAPISchema(type: APIDataType.array.type, items: openApiSchema)
-            storage.push(property: key.stringValue, withParameters: objectProperty)
+            storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
         }
     }
     
@@ -163,7 +191,7 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
             let additionalProperties = OpenAPISchema(type: dataType.type, format: dataType.format)
             let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
 
-            storage.push(property: key.stringValue, withParameters: objectProperty)
+            storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
         } else {
             guard self.isTypeReferenced(item.value) else {
                 return
@@ -172,7 +200,7 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
             let typeName = String(describing: type(of: item.value))
             let additionalProperties = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
             let objectProperty = OpenAPISchema(type: "object", additionalProperties: additionalProperties)
-            storage.push(property: key.stringValue, withParameters: objectProperty)
+            storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
         }
     }
         
@@ -183,12 +211,12 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
         
         let typeName = String(describing: type(of: value))
         let objectProperty = OpenAPISchema(ref: "#/components/schemas/\(typeName)")
-        storage.push(property: key.stringValue, withParameters: objectProperty)
+        storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
     }
     
     private func append(uuid: UUID, forKey key: Key) {
         let objectProperty = OpenAPISchema(type: APIDataType.uuid.type, format: APIDataType.uuid.format, example: AnyCodable(uuid.uuidString))
-        storage.push(property: key.stringValue, withParameters: objectProperty)
+        storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
     }
     
     private func append(date: Date, forKey key: Key) {
@@ -197,25 +225,27 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         let dateString = dateFormatter.string(from: date)
         
-        storage.push(property: key.stringValue,
+        storage.push(property: self.converted(key).stringValue,
                      withParameters: OpenAPISchema(type: APIDataType.dateTime.type, format: APIDataType.dateTime.format, example: AnyCodable(dateString)))
     }
     
     private func append<T>(complex value: T, forKey key: Key) where T : Encodable {
         
-        let internalEncoder = OpenAPISchemaEncoder(codingPath: [], referencedObjects: self.encoder.referencedObjects)
+        let internalEncoder = OpenAPISchemaEncoder(codingPath: [],
+                                                   referencedObjects: self.encoder.referencedObjects,
+                                                   keyEncodingStrategy: self.keyEncodingStrategy)
         try? value.encode(to: internalEncoder)
         
         // Encode simple values (e.g. property wrappers simple values).
         if let schemaItem = internalEncoder.storage.collection.first {
-            storage.push(property: key.stringValue, withParameters: schemaItem)
+            storage.push(property: self.converted(key).stringValue, withParameters: schemaItem)
             return
         }
         
         // Encode complex objects.
         if internalEncoder.storage.container.isEmpty == false {
             let objectProperty = OpenAPISchema(type: "object", properties: internalEncoder.storage.container)
-            storage.push(property: key.stringValue, withParameters: objectProperty)
+            storage.push(property: self.converted(key).stringValue, withParameters: objectProperty)
         }
     }
     
@@ -224,20 +254,17 @@ class OpenAPISchemaKeyedEncodingContainer<Key : CodingKey> : KeyedEncodingContai
         return self.encoder.referencedObjects.contains(where: { referencedObject in referencedObject == typeName })
     }
     
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: codingPath, wrapping: storage)
-        return KeyedEncodingContainer(container)
-    }
-    
-    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        return OpenAPISchemaUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath)
-    }
-    
-    func superEncoder() -> Encoder {
-        return self.encoder
-    }
-    
-    func superEncoder(forKey key: Key) -> Encoder {
-        return self.encoder
+    private func converted(_ key: Key) -> CodingKey {
+        switch self.keyEncodingStrategy {
+        case .useDefaultKeys:
+            return key
+        case .convertToSnakeCase:
+            let newKeyString = key.stringValue.snakeCase()
+            return PropertyKey(stringValue: newKeyString, intValue: key.intValue)
+        case .custom(let converter):
+            return converter(codingPath + [key])
+        @unknown default:
+            return key
+        }
     }
 }

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaStorage.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaStorage.swift
@@ -1,0 +1,18 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+class OpenAPISchemaStorage {
+    var container: [String: OpenAPISchema] = [:]
+    var collection: [OpenAPISchema] = []
+    
+    func push(property: String, withParameters schema: OpenAPISchema) {
+        self.container[property] = schema
+    }
+    
+    func push(parameter: OpenAPISchema) {
+        self.collection.append(parameter)
+    }
+}

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaUnkeyedEncodingContainer.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaUnkeyedEncodingContainer.swift
@@ -4,14 +4,18 @@
 //  Licensed under the MIT License.
 //
 
+import Foundation
+
 class OpenAPISchemaUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     let encoder: OpenAPISchemaEncoder
+    let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
     var codingPath: [CodingKey]
     var count: Int = 0
     
-    init(referencing encoder: OpenAPISchemaEncoder, codingPath: [CodingKey]) {
+    init(referencing encoder: OpenAPISchemaEncoder, codingPath: [CodingKey], keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy) {
         self.encoder = encoder
         self.codingPath = codingPath
+        self.keyEncodingStrategy = keyEncodingStrategy
     }
     
     func encode(_ value: Bool) throws { }
@@ -33,12 +37,17 @@ class OpenAPISchemaUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
         let storage = OpenAPISchemaStorage()
-        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: storage)
+        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder,
+                                                                       codingPath: self.codingPath,
+                                                                       wrapping: storage,
+                                                                       keyEncodingStrategy: self.keyEncodingStrategy)
         return KeyedEncodingContainer(container)
     }
     
     func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath)
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self.encoder,
+                                                     codingPath: self.codingPath,
+                                                     keyEncodingStrategy: self.keyEncodingStrategy)
     }
     
     func superEncoder() -> Encoder {

--- a/Sources/Swiftgger/Encoder/OpenAPISchemaUnkeyedEncodingContainer.swift
+++ b/Sources/Swiftgger/Encoder/OpenAPISchemaUnkeyedEncodingContainer.swift
@@ -1,0 +1,47 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+class OpenAPISchemaUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+    let encoder: OpenAPISchemaEncoder
+    var codingPath: [CodingKey]
+    var count: Int = 0
+    
+    init(referencing encoder: OpenAPISchemaEncoder, codingPath: [CodingKey]) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+    }
+    
+    func encode(_ value: Bool) throws { }
+    func encode(_ value: String) throws { }
+    func encode(_ value: Double) throws { }
+    func encode(_ value: Float) throws { }
+    func encode(_ value: Int) throws { }
+    func encode(_ value: Int8) throws { }
+    func encode(_ value: Int16) throws { }
+    func encode(_ value: Int32) throws { }
+    func encode(_ value: Int64) throws { }
+    func encode(_ value: UInt) throws { }
+    func encode(_ value: UInt8) throws { }
+    func encode(_ value: UInt16) throws { }
+    func encode(_ value: UInt32) throws { }
+    func encode(_ value: UInt64) throws { }
+    func encode<T>(_ value: T) throws where T : Encodable { }
+    func encodeNil() throws { }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        let storage = OpenAPISchemaStorage()
+        let container = OpenAPISchemaKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: storage)
+        return KeyedEncodingContainer(container)
+    }
+    
+    func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        return OpenAPISchemaUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath)
+    }
+    
+    func superEncoder() -> Encoder {
+        return self.encoder
+    }
+}

--- a/Sources/Swiftgger/Encoder/PropertyKey.swift
+++ b/Sources/Swiftgger/Encoder/PropertyKey.swift
@@ -1,0 +1,35 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+    
+
+import Foundation
+
+struct PropertyKey: CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    public init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
+
+    internal init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
+
+    internal static let `super` = PropertyKey(stringValue: "super")!
+}

--- a/Sources/Swiftgger/Extensions/Encodable+openEncode.swift
+++ b/Sources/Swiftgger/Extensions/Encodable+openEncode.swift
@@ -1,0 +1,13 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+    
+import Foundation
+
+extension Encodable {
+    func openedEncode(to container: inout SingleValueEncodingContainer) throws {
+        try container.encode(self)
+    }
+}

--- a/Sources/Swiftgger/Extensions/String+snakeCase.swift
+++ b/Sources/Swiftgger/Extensions/String+snakeCase.swift
@@ -1,0 +1,58 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+extension String {
+    
+    /// Convert string to snake_case. Orginal source: https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/JSONEncoder.swift.
+    func snakeCase() -> String {
+        let stringKey = self
+        guard !stringKey.isEmpty else { return stringKey }
+
+        var words: [Range<String.Index>] = []
+        var wordStart = stringKey.startIndex
+        var searchRange = stringKey.index(after: wordStart)..<stringKey.endIndex
+
+        // Find next uppercase character
+        while let upperCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.uppercaseLetters, options: [], range: searchRange) {
+            let untilUpperCase = wordStart..<upperCaseRange.lowerBound
+            words.append(untilUpperCase)
+
+            // Find next lowercase character
+            searchRange = upperCaseRange.lowerBound..<searchRange.upperBound
+            guard let lowerCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.lowercaseLetters, options: [], range: searchRange) else {
+                // There are no more lower case letters. Just end here.
+                wordStart = searchRange.lowerBound
+                break
+            }
+
+            // Is the next lowercase letter more than 1 after the uppercase? If so, we encountered a group of uppercase
+            // letters that we should treat as its own word
+            let nextCharacterAfterCapital = stringKey.index(after: upperCaseRange.lowerBound)
+            if lowerCaseRange.lowerBound == nextCharacterAfterCapital {
+                // The next character after capital is a lower case character and therefore not a word boundary.
+                // Continue searching for the next upper case for the boundary.
+                wordStart = upperCaseRange.lowerBound
+            } else {
+                // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
+                let beforeLowerIndex = stringKey.index(before: lowerCaseRange.lowerBound)
+                words.append(upperCaseRange.lowerBound..<beforeLowerIndex)
+
+                // Next word starts at the capital before the lowercase we just found
+                wordStart = beforeLowerIndex
+            }
+            searchRange = lowerCaseRange.upperBound..<searchRange.upperBound
+        }
+        
+        words.append(wordStart..<searchRange.upperBound)
+        let result = words.map({ (range) in
+            return stringKey[range].lowercased()
+        }).joined(separator: "_")
+
+        return result
+    }
+}

--- a/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
+++ b/Sources/Swiftgger/OpenAPIModel/OpenAPISchema.swift
@@ -27,23 +27,17 @@ public class OpenAPISchema: Codable {
          format: String? = nil,
          items: OpenAPISchema? = nil,
          required: [String]? = nil,
-         properties: [(name: String, type: OpenAPISchema)]? = nil,
+         properties: [String: OpenAPISchema]? = nil,
          example: AnyCodable? = nil,
          additionalProperties: OpenAPISchema? = nil
     ) {
         self.type = type
         self.format = format
         self.items = items
-        self.required = required
+        self.required = `required`
+        self.properties = properties
         self.example = example
         self.additionalProperties = additionalProperties
-
-        if let typeProperies = properties {
-            self.properties = [:]
-            for property in typeProperies {
-                self.properties![property.name] = property.type
-            }
-        }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/SwiftggerTestApp/Models/Fuel.swift
+++ b/Sources/SwiftggerTestApp/Models/Fuel.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-struct Fuel {
+struct Fuel: Encodable {
     var level: Int
     var type: String
     var productionDate: Date

--- a/Sources/SwiftggerTestApp/Models/Species.swift
+++ b/Sources/SwiftggerTestApp/Models/Species.swift
@@ -1,0 +1,18 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+    
+import Foundation
+
+struct Species: Encodable
+{
+    var name: String
+    var countryOfOrigin: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case countryOfOrigin = "country_of_origin"
+    }
+}

--- a/Sources/SwiftggerTestApp/Models/Vehicle.swift
+++ b/Sources/SwiftggerTestApp/Models/Vehicle.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-class Vehicle {
+class Vehicle: Encodable {
     var name: String
     var age: Int?
     var fuels: [Fuel]?

--- a/Sources/SwiftggerTestApp/Program.swift
+++ b/Sources/SwiftggerTestApp/Program.swift
@@ -35,7 +35,8 @@ class Program {
                                       ],
                                       keyId: UUID(),
                                       uuidIds: [UUID(), UUID(), UUID()])),
-            APIObject(object: Fuel(level: 90, type: "GAS", productionDate: Date(), parameters: ["power", "speed"]))
+            APIObject(object: Fuel(level: 90, type: "GAS", productionDate: Date(), parameters: ["power", "speed"])),
+            APIObject(object: Species(name: "Ant", countryOfOrigin: "Africa"))
         ])
         .add(APIController(name: "VehiclesController", description: "Contoller for vehicles", actions: [
             APIAction(method: .get,

--- a/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPIPathsBuilderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 // swiftlint:disable type_body_length file_length
 
-class Animal {
+class Animal: Encodable {
     var name: String
     var age: Int?
 

--- a/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
@@ -7,8 +7,7 @@
 import XCTest
 @testable import Swiftgger
 
-
-@propertyWrapper final class Flag<Value> {
+@propertyWrapper final class Flag<Value>: Encodable {
     let name: String
     var wrappedValue: Value
 
@@ -16,9 +15,31 @@ import XCTest
         self.name = name
         self.wrappedValue = defaultValue
     }
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+    }
 }
 
-class Vehicle {
+@propertyWrapper
+struct NullEncodable<T>: Encodable where T: Encodable {
+    
+    var wrappedValue: T?
+
+    init(wrappedValue: T?) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch wrappedValue {
+        case .some(let value): try container.encode(value)
+        case .none: try container.encodeNil()
+        }
+    }
+}
+
+class Vehicle: Encodable {
     var name: String
     var age: Int?
     var fuels: [Fuel]?
@@ -36,7 +57,7 @@ class Vehicle {
     }
 }
 
-struct Fuel {
+struct Fuel: Encodable {
     var level: Int
     var type: String
     var parameters: [String]
@@ -50,43 +71,59 @@ struct Fuel {
     }
 }
 
-struct Spaceship {
+struct Spaceship: Encodable {
     var name: String
     var speed: Double?
     var fuel: Fuel?
 
-    init(name: String, speed: Double, fuel: Fuel? = nil) {
+    init(name: String, speed: Double?, fuel: Fuel? = nil) {
         self.name = name
         self.speed = speed
         self.fuel = fuel
     }
 }
 
-class Alien {
+class Alien: Encodable {
     var spaceship: Spaceship
+    @NullEncodable var age: Int?
     
-    init(spaceship: Spaceship) {
+    init(spaceship: Spaceship, age: Int? = nil) {
         self.spaceship = spaceship
+        self.age = age
     }
 }
 
-class User {
+class User: Encodable {
     var vehicles: [Vehicle]
     var family: [String: Alien]?
+    var birthDate: Date?
 
-    init(vehicles: [Vehicle], family: [String: Alien]? = nil) {
+    init(vehicles: [Vehicle], family: [String: Alien]? = nil, birthDate: Date? = nil) {
         self.vehicles = vehicles
         self.family = family
+        self.birthDate = birthDate
     }
 }
 
-class VehicleKeys {
+class VehicleKeys: Encodable {
     var singleId: UUID
     var arrayIds: [UUID]
     
     init(singleId: UUID, arrayIds: [UUID]) {
         self.singleId = singleId
         self.arrayIds = arrayIds
+    }
+}
+
+struct Species: Encodable
+{
+    var id = 12
+    var name: String
+    var countryOfOrigin: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case countryOfOrigin = "country_of_origin"
     }
 }
 
@@ -198,46 +235,34 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"], "Integer property not exists in schema")
         XCTAssertEqual("integer", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.type)
-        XCTAssertEqual("int64", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.format)
+        XCTAssertEqual("int32", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.format)
         XCTAssertEqual(21, openAPIDocument.components?.schemas?["Vehicle"]?.properties?["age"]?.example)
     }
-
-    func testSchemaRequiredFieldsShouldBeTranslatedToOpenAPIDocument() {
+    
+    func testSchemaDatePropertyShouldBeTranslatedToOpenAPIDocument() {
 
         // Arrange.
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        let date = dateFormatter.date(from: "2012-04-23T18:25:43.511Z")!
+        
         let openAPIBuilder = OpenAPIBuilder(
             title: "Title",
             version: "1.0.0",
             description: "Description"
         )
         .add([
-            APIObject(object: Vehicle(name: "Ford", age: 21, wrappedString: "something"))
+            APIObject(object: User(vehicles: [], family: [:], birthDate: date))
         ])
 
         // Act.
         let openAPIDocument = openAPIBuilder.built()
 
         // Assert.
-        XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("name") == true, "Required property not exists in schema")
-    }
-
-    func testSchemaNotRequiredFieldsShouldNotBeTranslatedToOpenAPIDocument() {
-
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-            title: "Title",
-            version: "1.0.0",
-            description: "Description"
-        )
-        .add([
-            APIObject(object: Vehicle(name: "Ford", age: 21, wrappedString: "something"))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("age") == false, "Not required property exists in schema")
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["User"]?.properties?["birthDate"], "Integer property not exists in schema")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["User"]?.properties?["birthDate"]?.type)
+        XCTAssertEqual("date-time", openAPIDocument.components?.schemas?["User"]?.properties?["birthDate"]?.format)
+        XCTAssertEqual("2012-04-23T18:25:43.511Z", openAPIDocument.components?.schemas?["User"]?.properties?["birthDate"]?.example)
     }
 
     func testSchemaStructTypeShouldBeTranslatedToOpenAPIDocument() {
@@ -280,121 +305,6 @@ class OpenAPISchemasBuilderTests: XCTestCase {
       // Assert.
       XCTAssertNotNil(openAPIDocument.components?.schemas?["CustomSpaceship"], "Custom Schema name not exists")
     }
-
-    func testSchemaWithNestedObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: Alien(spaceship: Spaceship(name: "Star Trek", speed: 2122)))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Spaceship"], "Spaceship schema not exists")
-        XCTAssertEqual("#/components/schemas/Spaceship", openAPIDocument.components?.schemas?["Alien"]?.properties?["spaceship"]?.ref)
-    }
-
-    func testSchemaWithNestedArrayOfObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: User(vehicles: [Vehicle(name: "Star Trek", age: 3, wrappedString: "something")]))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"], "Vehicle schema not exists")
-        XCTAssertEqual("array", openAPIDocument.components?.schemas?["User"]?.properties?["vehicles"]?.type)
-        XCTAssertEqual("#/components/schemas/Vehicle", openAPIDocument.components?.schemas?["User"]?.properties?["vehicles"]?.items?.ref)
-    }
-
-    func testSchemaWithOptionalNestedObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: Alien(spaceship: Spaceship(name: "Star Trek", speed: 2122))),
-            APIObject(object: Spaceship(name: "Star Trek", speed: 2122, fuel: Fuel(level: 90, type: "E95", parameters: ["power"])))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
-        XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["fuel"]?.ref)
-    }
-    
-    func testSchemaWithOptionalNestedArrayOfObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: Vehicle(name: "Star Trek", age: 3, wrappedString: "something", fuels: [Fuel(level: 10, type: "GAS", parameters: ["power"])]))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
-        XCTAssertEqual("array", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.type)
-        XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.items?.ref)
-    }
-    
-    func testSchemaWithNonInitializedOptionalNestedObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: Alien(spaceship: Spaceship(name: "Star Trek", speed: 2122))),
-            APIObject(object: Spaceship(name: "Star Trek", speed: 2122)),
-            APIObject(object: Fuel(level: 90, type: "E95", parameters: ["power"]))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
-        XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Spaceship"]?.properties?["fuel"]?.ref)
-    }
-    
-    func testSchemaWithNonInitializedOptionalNestedArrayOfObjectsShouldBeTranslatedToOpenAPIDocument() {
-        // Arrange.
-        let openAPIBuilder = OpenAPIBuilder(
-          title: "Title",
-          version: "1.0.0",
-          description: "Description"
-        ).add([
-            APIObject(object: Vehicle(name: "Star Trek", age: 3, wrappedString: "something")),
-            APIObject(object: Fuel(level: 10, type: "GAS", parameters: ["power"]))
-        ])
-
-        // Act.
-        let openAPIDocument = openAPIBuilder.built()
-
-        // Assert.
-        XCTAssertNotNil(openAPIDocument.components?.schemas?["Fuel"], "Fuel schema not exists")
-        XCTAssertEqual("array", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.type)
-        XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["fuels"]?.items?.ref)
-    }
     
     func testSchemaPropertyWrapperForStringShouldBeTranslatedToOpenAPIDocument() {
 
@@ -413,8 +323,9 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedString"], "Wrapped string property not exists in schema")
-        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedString"]?.type)
-        XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("wrappedString") == true, "Required property not exists in schema")
+        XCTAssertEqual("object", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedString"]?.type)
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedString"]?.properties?["name"]?.type)
+        // XCTAssert(openAPIDocument.components?.schemas?["Vehicle"]?.required?.contains("wrappedString") == true, "Required property not exists in schema")
     }
     
     func testSchemaPropertyWrapperForStructShouldBeTranslatedToOpenAPIDocument() {
@@ -434,7 +345,30 @@ class OpenAPISchemasBuilderTests: XCTestCase {
 
         // Assert.
         XCTAssertNotNil(openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedFuel"], "Wrapped struct property not exists in schema")
-        XCTAssertEqual("#/components/schemas/Fuel", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedFuel"]?.ref)
+        XCTAssertEqual("object", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedFuel"]?.type)
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Vehicle"]?.properties?["wrappedFuel"]?.properties?["name"]?.type)
+    }
+    
+    func testSchemaPropertyWrapperSingleValueContainerShouldBeTranslatedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add([
+            APIObject(object: Spaceship(name: "UFO", speed: 12)),
+            APIObject(object: Alien(spaceship: Spaceship(name: "UFO", speed: 12), age: 21))
+        ])
+        
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Alien"]?.properties?["age"], "Wrapped struct property not exists in schema")
+        XCTAssertEqual("integer", openAPIDocument.components?.schemas?["Alien"]?.properties?["age"]?.type)
+        XCTAssertEqual("int32", openAPIDocument.components?.schemas?["Alien"]?.properties?["age"]?.format)
     }
     
     func testSchemaWithArrayOfStringShouldBeTranslatedToOpenAPIDocument() {
@@ -493,7 +427,9 @@ class OpenAPISchemasBuilderTests: XCTestCase {
             description: "Description"
         )
         .add([
-            APIObject(object: User(vehicles: [], family: ["Fred": Alien(spaceship: Spaceship(name: "", speed: 12))]))
+            APIObject(object: User(vehicles: [], family: ["Fred": Alien(spaceship: Spaceship(name: "", speed: 12))])),
+            APIObject(object: Alien(spaceship: Spaceship(name: "", speed: 12))),
+            APIObject(object: Spaceship(name: "", speed: 12))
         ])
         
         // Act.
@@ -554,5 +490,30 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         XCTAssertNotNil(example, "Example array not exists")
         XCTAssertEqual("CE30476C-B335-41A8-9E68-1C0C98DCEB60", example![0])
         XCTAssertEqual("B5728916-CD90-4A88-ABFD-23576BA563DA", example![1])
+    }
+    
+    func testSchemaWithCodingKeysShouldBeTranslatedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add([
+            APIObject(object: Species(name: "Ant", countryOfOrigin: "Africa"))
+        ])
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+        
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Species"]?.properties?["name"], "Name property not exists in schema")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Species"]?.properties?["name"]?.type)
+        XCTAssertEqual("Ant", openAPIDocument.components?.schemas?["Species"]?.properties?["name"]?.example)
+        
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["Species"]?.properties?["country_of_origin"], "Country of origin property not exists in schema")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["Species"]?.properties?["country_of_origin"]?.type)
+        XCTAssertEqual("Africa", openAPIDocument.components?.schemas?["Species"]?.properties?["country_of_origin"]?.example)
     }
 }

--- a/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
+++ b/Tests/SwiftggerTests/OpenAPISchemasBuilderTests.swift
@@ -516,4 +516,26 @@ class OpenAPISchemasBuilderTests: XCTestCase {
         XCTAssertEqual("string", openAPIDocument.components?.schemas?["Species"]?.properties?["country_of_origin"]?.type)
         XCTAssertEqual("Africa", openAPIDocument.components?.schemas?["Species"]?.properties?["country_of_origin"]?.example)
     }
+    
+    func testSchemaWithCustomEncodingStrategyShouldBeTranslatedToOpenAPIDocument() {
+
+        // Arrange.
+        let openAPIBuilder = OpenAPIBuilder(
+            title: "Title",
+            version: "1.0.0",
+            description: "Description"
+        )
+        .add([
+            APIObject(object: User(vehicles: [], family: [:], birthDate: Date()))
+        ])
+        .use(keyEncodingStrategy: .convertToSnakeCase)
+
+        // Act.
+        let openAPIDocument = openAPIBuilder.built()
+        
+        // Assert.
+        XCTAssertNotNil(openAPIDocument.components?.schemas?["User"]?.properties?["birth_date"], "birth_date property not exists in schema")
+        XCTAssertEqual("string", openAPIDocument.components?.schemas?["User"]?.properties?["birth_date"]?.type)
+        XCTAssertEqual("date-time", openAPIDocument.components?.schemas?["User"]?.properties?["birth_date"]?.format)
+    }
 }


### PR DESCRIPTION
Since now we have two methods for customise property names.

1. using `CodingKey` protocol (for specific class/struct):

```swift
struct Species: Encodable
{
    var id = 12
    var name: String
    var countryOfOrigin: String

    enum CodingKeys: String, CodingKey {
        case name
        case countryOfOrigin = "country_of_origin"
    }
}
``` 

2. using `keyEncodingStrategy` (for all objects):

```swift
        // Arrange.
        let openAPIBuilder = OpenAPIBuilder(
            title: "Title",
            version: "1.0.0",
            description: "Description"
        )
        .add([
            APIObject(object: User(vehicles: [], family: [:], birthDate: Date()))
        ])
        .use(keyEncodingStrategy: .convertToSnakeCase)
```

Exactly the same mechanism is used in `JSONEncode` thus now everything should be more consistent. That change requires that all specified objects now have to conform `Encodable` protocol.
